### PR TITLE
feat: Add canvas pan/scroll functionality with expanded workspace

### DIFF
--- a/packages/grapys-vue/src/views/GUI.vue
+++ b/packages/grapys-vue/src/views/GUI.vue
@@ -53,25 +53,26 @@ export default defineComponent({
       const handleMouseDown = (e: MouseEvent) => {
         // ノードやエッジ以外の場所でのみパンを開始
         const target = e.target as Element;
-        const isClickableElement = target.closest('.node') || target.closest('.edge') || target.tagName === 'BUTTON' || target.tagName === 'INPUT' || target.tagName === 'SELECT';
-        
+        const isClickableElement =
+          target.closest(".node") || target.closest(".edge") || target.tagName === "BUTTON" || target.tagName === "INPUT" || target.tagName === "SELECT";
+
         if (!isClickableElement) {
           isPanning = true;
           startX = e.clientX;
           startY = e.clientY;
           scrollLeftStart = container.scrollLeft;
           scrollTopStart = container.scrollTop;
-          container.style.cursor = 'grabbing';
+          container.style.cursor = "grabbing";
           e.preventDefault();
         }
       };
 
       const handleMouseMove = (e: MouseEvent) => {
         if (!isPanning) return;
-        
+
         const deltaX = e.clientX - startX;
         const deltaY = e.clientY - startY;
-        
+
         container.scrollLeft = scrollLeftStart - deltaX;
         container.scrollTop = scrollTopStart - deltaY;
         e.preventDefault();
@@ -79,14 +80,15 @@ export default defineComponent({
 
       const handleMouseUp = () => {
         isPanning = false;
-        container.style.cursor = 'grab';
+        container.style.cursor = "grab";
       };
 
       // タッチでのパン操作
       const handleTouchStart = (e: TouchEvent) => {
         const target = e.target as Element;
-        const isClickableElement = target.closest('.node') || target.closest('.edge') || target.tagName === 'BUTTON' || target.tagName === 'INPUT' || target.tagName === 'SELECT';
-        
+        const isClickableElement =
+          target.closest(".node") || target.closest(".edge") || target.tagName === "BUTTON" || target.tagName === "INPUT" || target.tagName === "SELECT";
+
         if (!isClickableElement) {
           isPanning = true;
           startX = e.touches[0].clientX;
@@ -99,10 +101,10 @@ export default defineComponent({
 
       const handleTouchMove = (e: TouchEvent) => {
         if (!isPanning) return;
-        
+
         const deltaX = e.touches[0].clientX - startX;
         const deltaY = e.touches[0].clientY - startY;
-        
+
         container.scrollLeft = scrollLeftStart - deltaX;
         container.scrollTop = scrollTopStart - deltaY;
         e.preventDefault();
@@ -116,7 +118,7 @@ export default defineComponent({
       const handleWheel = (e: WheelEvent) => {
         const { deltaX, deltaY } = e;
         const { scrollLeft, scrollTop, scrollWidth, scrollHeight, clientWidth, clientHeight } = container;
-        
+
         // 水平スクロールが可能な場合のみ、デフォルト動作を防ぐ
         if (Math.abs(deltaX) > Math.abs(deltaY)) {
           // 左端で左スクロール、または右端で右スクロールの場合はブラウザの動作を許可
@@ -136,18 +138,18 @@ export default defineComponent({
       };
 
       // イベントリスナーの追加
-      container.addEventListener('mousedown', handleMouseDown);
-      document.addEventListener('mousemove', handleMouseMove);
-      document.addEventListener('mouseup', handleMouseUp);
-      
-      container.addEventListener('touchstart', handleTouchStart, { passive: false });
-      container.addEventListener('touchmove', handleTouchMove, { passive: false });
-      container.addEventListener('touchend', handleTouchEnd);
-      
-      container.addEventListener('wheel', handleWheel, { passive: false });
+      container.addEventListener("mousedown", handleMouseDown);
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+
+      container.addEventListener("touchstart", handleTouchStart, { passive: false });
+      container.addEventListener("touchmove", handleTouchMove, { passive: false });
+      container.addEventListener("touchend", handleTouchEnd);
+
+      container.addEventListener("wheel", handleWheel, { passive: false });
 
       // 初期カーソルスタイル
-      container.style.cursor = 'grab';
+      container.style.cursor = "grab";
     };
 
     onMounted(() => {
@@ -229,44 +231,49 @@ export default defineComponent({
         <SideMenu />
       </aside>
       <main class="flex-1">
-        <div ref="mainContainer" class="relative overflow-auto rounded-md border-4 border-gray-200" style="width: calc(100vw - 192px); height: calc(100vh - 40px);" @click="closeMenu">
-          <div class="relative" style="width: 2000px; height: 1500px;">
+        <div
+          ref="mainContainer"
+          class="relative overflow-auto rounded-md border-4 border-gray-200"
+          style="width: calc(100vw - 192px); height: calc(100vh - 40px)"
+          @click="closeMenu"
+        >
+          <div class="relative" style="width: 2000px; height: 1500px">
             <Loop />
             <svg x="0" y="0" class="pointer-events-none absolute h-full w-full" ref="svgRef">
-            <Edge
-              v-for="(edge, index) in edgeDataList"
-              :key="['edge', edge.source, edge.target, index].join('-')"
-              :source-data="edge.source"
-              :target-data="edge.target"
-              class="pointer-events-auto"
-              @dblclick="(e) => openEdgeMenu(e, index)"
-            />
-            <Edge
-              v-if="newEdgeData"
-              :source-data="newEdgeData.source"
-              :target-data="newEdgeData.target"
-              class="pointer-events-auto"
+              <Edge
+                v-for="(edge, index) in edgeDataList"
+                :key="['edge', edge.source, edge.target, index].join('-')"
+                :source-data="edge.source"
+                :target-data="edge.target"
+                class="pointer-events-auto"
+                @dblclick="(e) => openEdgeMenu(e, index)"
+              />
+              <Edge
+                v-if="newEdgeData"
+                :source-data="newEdgeData.source"
+                :target-data="newEdgeData.target"
+                class="pointer-events-auto"
+                :is-connectable="edgeConnectable"
+              />
+            </svg>
+            <Node
+              v-for="(node, index) in store.nodes"
+              :key="[node.nodeId, index].join('-')"
+              :node-index="index"
+              :node-data="node"
+              :nearest-data="nearestData"
               :is-connectable="edgeConnectable"
+              @update-position="(pos) => updateNodePosition(index, pos)"
+              @update-static-node-value="(value) => updateStaticNodeValue(index, value, true)"
+              @update-nested-graph="(value) => updateNestedGraph(index, value)"
+              @save-position="saveNodePosition"
+              @new-edge-start="onNewEdgeStart"
+              @new-edge="onNewEdge"
+              @new-edge-end="onNewEdgeEnd"
+              @open-node-menu="(event) => openNodeMenu(event, index)"
             />
-          </svg>
-          <Node
-            v-for="(node, index) in store.nodes"
-            :key="[node.nodeId, index].join('-')"
-            :node-index="index"
-            :node-data="node"
-            :nearest-data="nearestData"
-            :is-connectable="edgeConnectable"
-            @update-position="(pos) => updateNodePosition(index, pos)"
-            @update-static-node-value="(value) => updateStaticNodeValue(index, value, true)"
-            @update-nested-graph="(value) => updateNestedGraph(index, value)"
-            @save-position="saveNodePosition"
-            @new-edge-start="onNewEdgeStart"
-            @new-edge="onNewEdge"
-            @new-edge-end="onNewEdgeEnd"
-            @open-node-menu="(event) => openNodeMenu(event, index)"
-          />
-          <ContextEdgeMenu ref="contextEdgeMenu" />
-          <ContextNodeMenu ref="contextNodeMenu" />
+            <ContextEdgeMenu ref="contextEdgeMenu" />
+            <ContextNodeMenu ref="contextNodeMenu" />
           </div>
         </div>
         <div class="h-100vh pointer-events-none absolute top-0 right-0 z-10 flex max-h-screen flex-col items-end space-y-4 pt-4 pr-4 pb-4">

--- a/packages/grapys-vue/src/views/GUI.vue
+++ b/packages/grapys-vue/src/views/GUI.vue
@@ -35,11 +35,124 @@ export default defineComponent({
     const store = useStore();
     const contextEdgeMenu = ref();
     const contextNodeMenu = ref();
-
+    const mainContainer = ref();
     store.initFromGraphData(graphChat);
+
+    // パン（掴んで動かす）とスクロール機能のセットアップ
+    const setupPanAndScroll = () => {
+      const container = mainContainer.value;
+      if (!container) return;
+
+      let isPanning = false;
+      let startX = 0;
+      let startY = 0;
+      let scrollLeftStart = 0;
+      let scrollTopStart = 0;
+
+      // マウスでのパン操作
+      const handleMouseDown = (e: MouseEvent) => {
+        // ノードやエッジ以外の場所でのみパンを開始
+        const target = e.target as Element;
+        const isClickableElement = target.closest('.node') || target.closest('.edge') || target.tagName === 'BUTTON' || target.tagName === 'INPUT' || target.tagName === 'SELECT';
+        
+        if (!isClickableElement) {
+          isPanning = true;
+          startX = e.clientX;
+          startY = e.clientY;
+          scrollLeftStart = container.scrollLeft;
+          scrollTopStart = container.scrollTop;
+          container.style.cursor = 'grabbing';
+          e.preventDefault();
+        }
+      };
+
+      const handleMouseMove = (e: MouseEvent) => {
+        if (!isPanning) return;
+        
+        const deltaX = e.clientX - startX;
+        const deltaY = e.clientY - startY;
+        
+        container.scrollLeft = scrollLeftStart - deltaX;
+        container.scrollTop = scrollTopStart - deltaY;
+        e.preventDefault();
+      };
+
+      const handleMouseUp = () => {
+        isPanning = false;
+        container.style.cursor = 'grab';
+      };
+
+      // タッチでのパン操作
+      const handleTouchStart = (e: TouchEvent) => {
+        const target = e.target as Element;
+        const isClickableElement = target.closest('.node') || target.closest('.edge') || target.tagName === 'BUTTON' || target.tagName === 'INPUT' || target.tagName === 'SELECT';
+        
+        if (!isClickableElement) {
+          isPanning = true;
+          startX = e.touches[0].clientX;
+          startY = e.touches[0].clientY;
+          scrollLeftStart = container.scrollLeft;
+          scrollTopStart = container.scrollTop;
+          e.preventDefault();
+        }
+      };
+
+      const handleTouchMove = (e: TouchEvent) => {
+        if (!isPanning) return;
+        
+        const deltaX = e.touches[0].clientX - startX;
+        const deltaY = e.touches[0].clientY - startY;
+        
+        container.scrollLeft = scrollLeftStart - deltaX;
+        container.scrollTop = scrollTopStart - deltaY;
+        e.preventDefault();
+      };
+
+      const handleTouchEnd = () => {
+        isPanning = false;
+      };
+
+      // ホイールイベントでのスクロール制御
+      const handleWheel = (e: WheelEvent) => {
+        const { deltaX, deltaY } = e;
+        const { scrollLeft, scrollTop, scrollWidth, scrollHeight, clientWidth, clientHeight } = container;
+        
+        // 水平スクロールが可能な場合のみ、デフォルト動作を防ぐ
+        if (Math.abs(deltaX) > Math.abs(deltaY)) {
+          // 左端で左スクロール、または右端で右スクロールの場合はブラウザの動作を許可
+          if ((scrollLeft <= 0 && deltaX < 0) || (scrollLeft >= scrollWidth - clientWidth && deltaX > 0)) {
+            return;
+          }
+          e.preventDefault();
+          container.scrollLeft += deltaX;
+        } else {
+          // 垂直スクロールが可能な場合のみ、デフォルト動作を防ぐ
+          if ((scrollTop <= 0 && deltaY < 0) || (scrollTop >= scrollHeight - clientHeight && deltaY > 0)) {
+            return;
+          }
+          e.preventDefault();
+          container.scrollTop += deltaY;
+        }
+      };
+
+      // イベントリスナーの追加
+      container.addEventListener('mousedown', handleMouseDown);
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+      
+      container.addEventListener('touchstart', handleTouchStart, { passive: false });
+      container.addEventListener('touchmove', handleTouchMove, { passive: false });
+      container.addEventListener('touchend', handleTouchEnd);
+      
+      container.addEventListener('wheel', handleWheel, { passive: false });
+
+      // 初期カーソルスタイル
+      container.style.cursor = 'grab';
+    };
 
     onMounted(() => {
       saveNodePosition();
+      setupPanAndScroll();
     });
 
     const updateNodePosition = (index: number, pos: NodePosition) => {
@@ -103,6 +216,7 @@ export default defineComponent({
 
       showJsonView,
       showChat,
+      mainContainer,
     };
   },
 });
@@ -115,9 +229,10 @@ export default defineComponent({
         <SideMenu />
       </aside>
       <main class="flex-1">
-        <div class="relative h-[100vh] overflow-hidden rounded-md border-4 border-gray-200" @click="closeMenu">
-          <Loop />
-          <svg x="0" y="0" class="pointer-events-none absolute h-[100%] w-full" ref="svgRef">
+        <div ref="mainContainer" class="relative overflow-auto rounded-md border-4 border-gray-200" style="width: calc(100vw - 192px); height: calc(100vh - 40px);" @click="closeMenu">
+          <div class="relative" style="width: 2000px; height: 1500px;">
+            <Loop />
+            <svg x="0" y="0" class="pointer-events-none absolute h-full w-full" ref="svgRef">
             <Edge
               v-for="(edge, index) in edgeDataList"
               :key="['edge', edge.source, edge.target, index].join('-')"
@@ -152,6 +267,7 @@ export default defineComponent({
           />
           <ContextEdgeMenu ref="contextEdgeMenu" />
           <ContextNodeMenu ref="contextNodeMenu" />
+          </div>
         </div>
         <div class="h-100vh pointer-events-none absolute top-0 right-0 z-10 flex max-h-screen flex-col items-end space-y-4 pt-4 pr-4 pb-4">
           <div class="flex flex-row items-start space-x-4">

--- a/packages/grapys-vue/src/views/GUI.vue
+++ b/packages/grapys-vue/src/views/GUI.vue
@@ -70,11 +70,16 @@ export default defineComponent({
         // ノードやエッジ以外の場所でのみパンを開始
         const target = event.target as Element;
         const isClickableElement =
-          target.closest(".node") || target.closest(".edge") || target.tagName === "BUTTON" || target.tagName === "INPUT" || target.tagName === "SELECT" || target.tagName === "TEXTAREA";
+          target.closest(".node") ||
+          target.closest(".edge") ||
+          target.tagName === "BUTTON" ||
+          target.tagName === "INPUT" ||
+          target.tagName === "SELECT" ||
+          target.tagName === "TEXTAREA";
 
         // フォーカスされているtextareaがある場合はblurさせる
         const focusedTextarea = document.activeElement as HTMLTextAreaElement;
-        if (focusedTextarea && focusedTextarea.tagName === 'TEXTAREA' && !isClickableElement) {
+        if (focusedTextarea && focusedTextarea.tagName === "TEXTAREA" && !isClickableElement) {
           focusedTextarea.blur();
         }
 
@@ -114,11 +119,16 @@ export default defineComponent({
 
         const target = event.target as Element;
         const isClickableElement =
-          target.closest(".node") || target.closest(".edge") || target.tagName === "BUTTON" || target.tagName === "INPUT" || target.tagName === "SELECT" || target.tagName === "TEXTAREA";
+          target.closest(".node") ||
+          target.closest(".edge") ||
+          target.tagName === "BUTTON" ||
+          target.tagName === "INPUT" ||
+          target.tagName === "SELECT" ||
+          target.tagName === "TEXTAREA";
 
         // フォーカスされているtextareaがある場合はblurさせる
         const focusedTextarea = document.activeElement as HTMLTextAreaElement;
-        if (focusedTextarea && focusedTextarea.tagName === 'TEXTAREA' && !isClickableElement) {
+        if (focusedTextarea && focusedTextarea.tagName === "TEXTAREA" && !isClickableElement) {
           focusedTextarea.blur();
         }
 
@@ -252,7 +262,7 @@ export default defineComponent({
       showJsonView,
       showChat,
       mainContainer,
-      
+
       handleNodeDragStart,
       handleNodeDragEnd,
     };

--- a/packages/grapys-vue/src/views/Node.vue
+++ b/packages/grapys-vue/src/views/Node.vue
@@ -103,7 +103,18 @@ export default defineComponent({
       default: true,
     },
   },
-  emits: ["updatePosition", "savePosition", "newEdgeStart", "newEdge", "newEdgeEnd", "updateStaticNodeValue", "updateNestedGraph", "openNodeMenu", "nodeDragStart", "nodeDragEnd"],
+  emits: [
+    "updatePosition",
+    "savePosition",
+    "newEdgeStart",
+    "newEdge",
+    "newEdgeEnd",
+    "updateStaticNodeValue",
+    "updateNestedGraph",
+    "openNodeMenu",
+    "nodeDragStart",
+    "nodeDragEnd",
+  ],
   setup(props, ctx) {
     const store = useStore();
 

--- a/packages/grapys-vue/src/views/Node.vue
+++ b/packages/grapys-vue/src/views/Node.vue
@@ -103,7 +103,7 @@ export default defineComponent({
       default: true,
     },
   },
-  emits: ["updatePosition", "savePosition", "newEdgeStart", "newEdge", "newEdgeEnd", "updateStaticNodeValue", "updateNestedGraph", "openNodeMenu"],
+  emits: ["updatePosition", "savePosition", "newEdgeStart", "newEdge", "newEdgeEnd", "updateStaticNodeValue", "updateNestedGraph", "openNodeMenu", "nodeDragStart", "nodeDragEnd"],
   setup(props, ctx) {
     const store = useStore();
 
@@ -130,6 +130,7 @@ export default defineComponent({
         return;
       }
       isDragging.value = true;
+      ctx.emit("nodeDragStart");
       const { clientX, clientY } = getClientPos(event);
       const position = props.nodeData.position;
       offset.value.x = clientX - position.x;
@@ -167,6 +168,7 @@ export default defineComponent({
 
     const onEndNode = () => {
       isDragging.value = false;
+      ctx.emit("nodeDragEnd");
       if (deltaDistance > deltaDistanceThredhold) {
         ctx.emit("savePosition");
       }


### PR DESCRIPTION
- キャンバス背景でのドラッグパン操作を有効化
- タッチパッド対応の水平/垂直スクロール機能を追加
- 水平スクロール時のブラウザ戻るナビゲーションを防止
- より大きなワークスペースのためキャンバスサイズを2000x1500pxに拡張 	
- calc(100vw - 192px)幅でレスポンシブレイアウトを改善 
- ノードとの相互作用との競合を避けるスマートクリック検出を追加