### PR TITLE
Refactor GUI pan/scroll functionality and fix edge creation conflicts

### DIFF
--- a/packages/grapys-vue/README.md
+++ b/packages/grapys-vue/README.md
@@ -17,3 +17,44 @@ This runs entirely within your browser, so your API key is never stored or sent 
 ```
 VITE_OPEN_API_KEY=xxxx yarn run dev
 ```
+
+# GUI Test Items
+
+Please test the following operations in order to confirm that the pan and scroll functions work properly:
+
+## 1. Node Addition
+- [ ] Add a node from the side menu
+- [ ] Confirm that pan operations work normally after addition
+
+## 2. Node Movement
+- [ ] Move a node by drag and drop
+- [ ] Confirm that the canvas does not move during movement
+
+## 3. Node Deletion
+- [ ] Double-click on a node to display the context menu
+- [ ] Confirm that pan operations work normally after node deletion
+
+## 4. Edge (Line) Creation
+- [ ] Draw a line from the output port (right circle) to the input port (left circle) of nodes
+- [ ] Confirm that the canvas does not move while drawing the line
+
+## 5. Edge Deletion
+- [ ] Double-click on an existing edge (line) to display the context menu
+- [ ] Confirm that pan operations work normally after edge deletion
+
+## 6. Text Area Operations
+- [ ] Tap on the text area inside a node to expand the node
+- [ ] Tap outside the node to return it to its original size
+
+## 7. Text Selection Within Nodes
+- [ ] Select text inside a node using the trackpad
+- [ ] Confirm that the canvas does not move during text selection
+
+## 8. Config/Chat Screen
+- [ ] Open the config/chat screen using the button in the top right
+- [ ] Confirm that text selection is possible with the trackpad within the screen
+- [ ] Confirm that pan operations work normally after closing the screen
+
+## 9. Canvas Pan Operations
+- [ ] Drag empty areas to move the entire canvas
+- [ ] Perform scroll operations with the trackpad

--- a/packages/grapys-vue/src/composable/usePanAndScroll.ts
+++ b/packages/grapys-vue/src/composable/usePanAndScroll.ts
@@ -1,8 +1,10 @@
 import { ref, Ref } from 'vue';
+import { NewEdgeData } from '../utils/gui/type';
 
 export function usePanAndScroll(
   mainContainer: Ref<HTMLElement | undefined>,
-  isNodeDragging: Ref<boolean>
+  isNodeDragging: Ref<boolean>,
+  newEdgeData?: Ref<NewEdgeData | null>
 ) {
   const setupPanAndScroll = () => {
     const container = mainContainer.value;
@@ -18,6 +20,11 @@ export function usePanAndScroll(
     const startPanning = (clientX: number, clientY: number, target: Element, event: Event) => {
       // ノードがドラッグ中の場合はパン操作を無効にする
       if (isNodeDragging.value) {
+        return false;
+      }
+
+      // エッジ作成中の場合はパン操作を無効にする
+      if (newEdgeData?.value) {
         return false;
       }
 

--- a/packages/grapys-vue/src/composable/usePanAndScroll.ts
+++ b/packages/grapys-vue/src/composable/usePanAndScroll.ts
@@ -1,0 +1,150 @@
+import { ref, Ref } from 'vue';
+
+export function usePanAndScroll(
+  mainContainer: Ref<HTMLElement | undefined>,
+  isNodeDragging: Ref<boolean>
+) {
+  const setupPanAndScroll = () => {
+    const container = mainContainer.value;
+    if (!container) return;
+
+    let isPanning = false;
+    let startX = 0;
+    let startY = 0;
+    let scrollLeftStart = 0;
+    let scrollTopStart = 0;
+
+    // 共通のパン開始処理
+    const startPanning = (clientX: number, clientY: number, target: Element, event: Event) => {
+      // ノードがドラッグ中の場合はパン操作を無効にする
+      if (isNodeDragging.value) {
+        return false;
+      }
+
+      // ノードやエッジ以外の場所でのみパンを開始
+      const isClickableElement =
+        target.closest(".node") ||
+        target.closest(".edge") ||
+        target.tagName === "BUTTON" ||
+        target.tagName === "INPUT" ||
+        target.tagName === "SELECT" ||
+        target.tagName === "TEXTAREA";
+
+      // フォーカスされているtextareaがある場合はblurさせる
+      const focusedTextarea = document.activeElement as HTMLTextAreaElement;
+      if (focusedTextarea && focusedTextarea.tagName === 'TEXTAREA' && !isClickableElement) {
+        focusedTextarea.blur();
+      }
+
+      if (!isClickableElement) {
+        isPanning = true;
+        startX = clientX;
+        startY = clientY;
+        scrollLeftStart = container.scrollLeft;
+        scrollTopStart = container.scrollTop;
+        container.style.cursor = "grabbing";
+        event.preventDefault();
+        return true;
+      }
+      return false;
+    };
+
+    // 共通のパン移動処理
+    const updatePanning = (clientX: number, clientY: number, event: Event) => {
+      if (!isPanning) return;
+
+      const deltaX = clientX - startX;
+      const deltaY = clientY - startY;
+
+      container.scrollLeft = scrollLeftStart - deltaX;
+      container.scrollTop = scrollTopStart - deltaY;
+      event.preventDefault();
+    };
+
+    // 共通のパン終了処理
+    const endPanning = () => {
+      isPanning = false;
+      container.style.cursor = "grab";
+    };
+
+    // マウスでのパン操作
+    const handleMouseDown = (event: MouseEvent) => {
+      startPanning(event.clientX, event.clientY, event.target as Element, event);
+    };
+
+    const handleMouseMove = (event: MouseEvent) => {
+      updatePanning(event.clientX, event.clientY, event);
+    };
+
+    const handleMouseUp = () => {
+      endPanning();
+    };
+
+    // タッチでのパン操作
+    const handleTouchStart = (event: TouchEvent) => {
+      startPanning(event.touches[0].clientX, event.touches[0].clientY, event.target as Element, event);
+    };
+
+    const handleTouchMove = (event: TouchEvent) => {
+      updatePanning(event.touches[0].clientX, event.touches[0].clientY, event);
+    };
+
+    const handleTouchEnd = () => {
+      endPanning();
+    };
+
+    // ホイールイベントでのスクロール制御
+    const handleWheel = (event: WheelEvent) => {
+      const { deltaX, deltaY } = event;
+      const { scrollLeft, scrollTop, scrollWidth, scrollHeight, clientWidth, clientHeight } = container;
+
+      // 水平スクロールが可能な場合のみ、デフォルト動作を防ぐ
+      if (Math.abs(deltaX) > Math.abs(deltaY)) {
+        // 左端で左スクロール、または右端で右スクロールの場合はブラウザの動作を許可
+        if ((scrollLeft <= 0 && deltaX < 0) || (scrollLeft >= scrollWidth - clientWidth && deltaX > 0)) {
+          return;
+        }
+        event.preventDefault();
+        container.scrollLeft += deltaX;
+      } else {
+        // 垂直スクロールが可能な場合のみ、デフォルト動作を防ぐ
+        if ((scrollTop <= 0 && deltaY < 0) || (scrollTop >= scrollHeight - clientHeight && deltaY > 0)) {
+          return;
+        }
+        event.preventDefault();
+        container.scrollTop += deltaY;
+      }
+    };
+
+    // イベントリスナーの追加
+    container.addEventListener('mousedown', handleMouseDown);
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+    
+    container.addEventListener('touchstart', handleTouchStart, { passive: false });
+    container.addEventListener('touchmove', handleTouchMove, { passive: false });
+    container.addEventListener('touchend', handleTouchEnd);
+    
+    container.addEventListener('wheel', handleWheel, { passive: false });
+
+    // 初期カーソルスタイル
+    container.style.cursor = "grab";
+
+    // クリーンアップ関数を返す
+    return () => {
+      container.removeEventListener('mousedown', handleMouseDown);
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+      
+      container.removeEventListener('touchstart', handleTouchStart);
+      container.removeEventListener('touchmove', handleTouchMove);
+      container.removeEventListener('touchend', handleTouchEnd);
+      
+      container.removeEventListener('wheel', handleWheel);
+    };
+  };
+
+  return {
+    setupPanAndScroll
+  };
+}

--- a/packages/grapys-vue/src/views/GUI.vue
+++ b/packages/grapys-vue/src/views/GUI.vue
@@ -17,6 +17,7 @@ import { EdgeData, NodePosition, UpdateStaticValue } from "../utils/gui/type";
 import { graphChat } from "../graph/chat_tinyswallow";
 
 import { useNewEdge } from "../composable/gui";
+import { usePanAndScroll } from "../composable/usePanAndScroll";
 import { guiEdgeData2edgeData } from "../utils/gui/utils";
 import { useStore } from "../store";
 
@@ -50,132 +51,7 @@ export default defineComponent({
     };
 
     // パン（掴んで動かす）とスクロール機能のセットアップ
-    const setupPanAndScroll = () => {
-      const container = mainContainer.value;
-      if (!container) return;
-
-      let isPanning = false;
-      let startX = 0;
-      let startY = 0;
-      let scrollLeftStart = 0;
-      let scrollTopStart = 0;
-
-      // 共通のパン開始処理
-      const startPanning = (clientX: number, clientY: number, target: Element, event: Event) => {
-        // ノードがドラッグ中の場合はパン操作を無効にする
-        if (isNodeDragging.value) {
-          return false;
-        }
-
-        // ノードやエッジ以外の場所でのみパンを開始
-        const isClickableElement =
-          target.closest(".node") ||
-          target.closest(".edge") ||
-          target.tagName === "BUTTON" ||
-          target.tagName === "INPUT" ||
-          target.tagName === "SELECT" ||
-          target.tagName === "TEXTAREA";
-
-        // フォーカスされているtextareaがある場合はblurさせる
-        const focusedTextarea = document.activeElement as HTMLTextAreaElement;
-        if (focusedTextarea && focusedTextarea.tagName === "TEXTAREA" && !isClickableElement) {
-          focusedTextarea.blur();
-        }
-
-        if (!isClickableElement) {
-          isPanning = true;
-          startX = clientX;
-          startY = clientY;
-          scrollLeftStart = container.scrollLeft;
-          scrollTopStart = container.scrollTop;
-          container.style.cursor = "grabbing";
-          event.preventDefault();
-          return true;
-        }
-        return false;
-      };
-
-      // 共通のパン移動処理
-      const updatePanning = (clientX: number, clientY: number, event: Event) => {
-        if (!isPanning) return;
-
-        const deltaX = clientX - startX;
-        const deltaY = clientY - startY;
-
-        container.scrollLeft = scrollLeftStart - deltaX;
-        container.scrollTop = scrollTopStart - deltaY;
-        event.preventDefault();
-      };
-
-      // 共通のパン終了処理
-      const endPanning = () => {
-        isPanning = false;
-        container.style.cursor = "grab";
-      };
-
-      // マウスでのパン操作
-      const handleMouseDown = (event: MouseEvent) => {
-        startPanning(event.clientX, event.clientY, event.target as Element, event);
-      };
-
-      const handleMouseMove = (event: MouseEvent) => {
-        updatePanning(event.clientX, event.clientY, event);
-      };
-
-      const handleMouseUp = () => {
-        endPanning();
-      };
-
-      // タッチでのパン操作
-      const handleTouchStart = (event: TouchEvent) => {
-        startPanning(event.touches[0].clientX, event.touches[0].clientY, event.target as Element, event);
-      };
-
-      const handleTouchMove = (event: TouchEvent) => {
-        updatePanning(event.touches[0].clientX, event.touches[0].clientY, event);
-      };
-
-      const handleTouchEnd = () => {
-        endPanning();
-      };
-
-      // ホイールイベントでのスクロール制御
-      const handleWheel = (event: WheelEvent) => {
-        const { deltaX, deltaY } = event;
-        const { scrollLeft, scrollTop, scrollWidth, scrollHeight, clientWidth, clientHeight } = container;
-
-        // 水平スクロールが可能な場合のみ、デフォルト動作を防ぐ
-        if (Math.abs(deltaX) > Math.abs(deltaY)) {
-          // 左端で左スクロール、または右端で右スクロールの場合はブラウザの動作を許可
-          if ((scrollLeft <= 0 && deltaX < 0) || (scrollLeft >= scrollWidth - clientWidth && deltaX > 0)) {
-            return;
-          }
-          event.preventDefault();
-          container.scrollLeft += deltaX;
-        } else {
-          // 垂直スクロールが可能な場合のみ、デフォルト動作を防ぐ
-          if ((scrollTop <= 0 && deltaY < 0) || (scrollTop >= scrollHeight - clientHeight && deltaY > 0)) {
-            return;
-          }
-          event.preventDefault();
-          container.scrollTop += deltaY;
-        }
-      };
-
-      // イベントリスナーの追加
-      container.addEventListener("mousedown", handleMouseDown);
-      document.addEventListener("mousemove", handleMouseMove);
-      document.addEventListener("mouseup", handleMouseUp);
-
-      container.addEventListener("touchstart", handleTouchStart, { passive: false });
-      container.addEventListener("touchmove", handleTouchMove, { passive: false });
-      container.addEventListener("touchend", handleTouchEnd);
-
-      container.addEventListener("wheel", handleWheel, { passive: false });
-
-      // 初期カーソルスタイル
-      container.style.cursor = "grab";
-    };
+    const { setupPanAndScroll } = usePanAndScroll(mainContainer, isNodeDragging);
 
     onMounted(() => {
       saveNodePosition();

--- a/packages/grapys-vue/src/views/GUI.vue
+++ b/packages/grapys-vue/src/views/GUI.vue
@@ -50,9 +50,6 @@ export default defineComponent({
       isNodeDragging.value = false;
     };
 
-    // パン（掴んで動かす）とスクロール機能のセットアップ
-    const { setupPanAndScroll } = usePanAndScroll(mainContainer, isNodeDragging);
-
     onMounted(() => {
       saveNodePosition();
       setupPanAndScroll();
@@ -76,6 +73,9 @@ export default defineComponent({
     });
 
     const { svgRef, newEdgeData, onNewEdgeStart, onNewEdge, onNewEdgeEnd, nearestData, edgeConnectable } = useNewEdge();
+
+    // パン（掴んで動かす）とスクロール機能のセットアップ
+    const { setupPanAndScroll } = usePanAndScroll(mainContainer, isNodeDragging, newEdgeData);
 
     const openEdgeMenu = (event: MouseEvent, edgeIndex: number) => {
       const rect = svgRef.value.getBoundingClientRect();


### PR DESCRIPTION
## feat: パン・スクロール機能を再利用可能なcomposableに抽出
- より良いコード構成のためにusePanAndScrollコンポーザブルを作成
- GUI.vueからパン・スクロールロジックを別ファイルに移動
- パン機能の保守性と再利用性を向上
- コンポーネントのアンマウント時に自動的にイベントリスナーをクリーンアップ
- パン・スクロール機能のテストとデバッグを容易化

## fix: エッジ作成時のキャンバスパンを防止して操作競合を回避
- usePanAndScrollコンポーザブルにnewEdgeDataパラメータを追加
- ノード間でエッジを作成中はパン操作をブロック
- エッジ描画とキャンバスパンの競合を解決
- ノード接続ワークフローのユーザーエクスペリエンスを改善

## add: GUIの手順書を追加
