### PR TITLE
fix: prevent canvas scroll when scrolling in focused text areas

### DIFF
--- a/packages/grapys-vue/qa_procedure.md
+++ b/packages/grapys-vue/qa_procedure.md
@@ -26,15 +26,22 @@ Please test the following operations in order to confirm that the pan and scroll
 - [ ] Tap on the text area inside a node to expand the node
 - [ ] Tap outside the node to return it to its original size
 
-## 7. Text Selection Within Nodes
+## 7. Text Area Scrolling
+- [ ] Focus on a text area inside a node (node should expand)
+- [ ] Enter multiple lines of text to make the content scrollable
+- [ ] Use trackpad to scroll up and down within the text area
+- [ ] Confirm that only the text area content scrolls, not the canvas
+- [ ] Confirm that text selection still works properly within the text area
+
+## 8. Text Selection Within Nodes
 - [ ] Select text inside a node using the trackpad
 - [ ] Confirm that the canvas does not move during text selection
 
-## 8. Config/Chat Screen
+## 9. Config/Chat Screen
 - [ ] Open the config/chat screen using the button in the top right
 - [ ] Confirm that text selection is possible with the trackpad within the screen
 - [ ] Confirm that pan operations work normally after closing the screen
 
-## 9. Canvas Pan Operations
+## 10. Canvas Pan Operations
 - [ ] Drag empty areas to move the entire canvas
 - [ ] Perform scroll operations with the trackpad

--- a/packages/grapys-vue/src/composable/usePanAndScroll.ts
+++ b/packages/grapys-vue/src/composable/usePanAndScroll.ts
@@ -102,6 +102,22 @@ export function usePanAndScroll(
 
     // ホイールイベントでのスクロール制御
     const handleWheel = (event: WheelEvent) => {
+      const target = event.target as Element;
+      
+      // フォーカスされたテキストエリア内でのスクロールの場合は、デフォルト動作を許可
+      const focusedTextarea = document.activeElement as HTMLTextAreaElement;
+      if (focusedTextarea && focusedTextarea.tagName === 'TEXTAREA') {
+        // イベントターゲットがフォーカスされたテキストエリア、またはその子要素の場合
+        if (target === focusedTextarea || focusedTextarea.contains(target)) {
+          return; // デフォルトのスクロール動作を許可
+        }
+      }
+      
+      // テキストエリア内でのスクロールの場合は、デフォルト動作を許可
+      if (target.tagName === 'TEXTAREA' || target.closest('textarea')) {
+        return; // デフォルトのスクロール動作を許可
+      }
+
       const { deltaX, deltaY } = event;
       const { scrollLeft, scrollTop, scrollWidth, scrollHeight, clientWidth, clientHeight } = container;
 

--- a/packages/grapys-vue/src/views/NodeComputedParam.vue
+++ b/packages/grapys-vue/src/views/NodeComputedParam.vue
@@ -13,6 +13,7 @@
         v-model="textAreaValue"
         @mousedown.stop
         @touchstart.stop
+        @wheel.stop
       ></textarea>
     </div>
     <div v-else-if="param.type === 'data'">
@@ -23,6 +24,7 @@
         v-model="textAreaValue"
         @mousedown.stop
         @touchstart.stop
+        @wheel.stop
       ></textarea>
     </div>
     <div v-else-if="param.type === 'int'">

--- a/packages/grapys-vue/src/views/NodeStaticValue.vue
+++ b/packages/grapys-vue/src/views/NodeStaticValue.vue
@@ -14,6 +14,7 @@
       :rows="rows"
       @mousedown.stop
       @touchstart.stop
+      @wheel.stop
     ></textarea>
     <div v-if="['data'].includes(dataType)">
       {{ isValidData ? "valid" : "invalid" }}


### PR DESCRIPTION
fix: prevent canvas scroll when scrolling in focused text areas

- Add wheel event detection in usePanAndScroll to allow text area scrolling
- Add @wheel.stop modifier to text areas in NodeStaticValue and NodeComputedParam
- Update QA procedure with text area scrolling test cases
- Fixes issue where trackpad scrolling in expanded node text areas would move canvas instead of scrolling text content

Files changed:
- packages/grapys-vue/src/composable/usePanAndScroll.ts
- packages/grapys-vue/src/views/NodeStaticValue.vue  
- packages/grapys-vue/src/views/NodeComputedParam.vue
- packages/grapys-vue/qa_procedure.md
