### PR TITLE
feat: Add 0.1 step increment for float parameters

### DIFF
--- a/packages/grapys-vue/src/utils/gui/type.ts
+++ b/packages/grapys-vue/src/utils/gui/type.ts
@@ -129,6 +129,7 @@ export type ParamData = {
   defaultValue?: number | boolean | string;
   max?: number;
   min?: number;
+  step?: number;
   values?: string[];
 };
 export type AgentProfile = {

--- a/packages/grapys-vue/src/views/NodeComputedParam.vue
+++ b/packages/grapys-vue/src/views/NodeComputedParam.vue
@@ -42,12 +42,13 @@
       />
     </div>
     <div v-else-if="param.type === 'float'">
-      <!-- TODO min, max, defaultValue -->
+      <!-- step can be customized per parameter, defaults to 0.1 for float inputs -->
+      <!-- min/max attributes are only set when param.min/max are defined (Vue automatically omits undefined attributes) -->
       <input
         ref="inputRef"
         type="number"
         class="w-full rounded-md border border-gray-300 p-1 text-black"
-        step="0.1"
+        :step="param.step ?? 0.1"
         :min="param.min"
         :max="param.max"
         v-model="inputValue"


### PR DESCRIPTION
feat: Add 0.1 step increment for float parameters

- Add step="0.1" to float input fields in NodeComputedParam.vue
- Add min/max attributes for proper range validation
- Fixes temperature parameter increment from integer to 0.1 steps