### PR TITLE
 Configure environment-based API URLs for production graph templates

### DIFF
--- a/packages/grapys-vue/src/config/game-dev.ts
+++ b/packages/grapys-vue/src/config/game-dev.ts
@@ -15,3 +15,5 @@ export const firebaseConfig = {
   appId: "1:185975114870:web:dc182434167838b326a357",
   measurementId: "G-117TSJ84PZ",
 };
+
+export const battleAPIBaseURL = "https://dev.aq-world.singularitybattlequest.club/api";

--- a/packages/grapys-vue/src/config/game.ts
+++ b/packages/grapys-vue/src/config/game.ts
@@ -7,3 +7,5 @@ export const firebaseConfig = {
   appId: "1:427990278188:web:0269a6cd684f5997d13189",
   measurementId: "G-DRQX8W22KB",
 };
+
+export const battleAPIBaseURL = "https://aq-world.singularitybattlequest.club/api";

--- a/packages/grapys-vue/src/graph/battle_player_prod.ts
+++ b/packages/grapys-vue/src/graph/battle_player_prod.ts
@@ -1,4 +1,5 @@
 import { GraphData } from "graphai";
+import { battleAPIBaseURL } from "../config/project";
 export const graphChat: GraphData = {
   "version": 0.5,
   "nodes": {
@@ -57,7 +58,7 @@ export const graphChat: GraphData = {
       "agent": "vanillaFetchAgent",
       "params": {},
       "inputs": {
-        "url": "https://aq-world.singularitybattlequest.club/api/${:gameid}/game_state"
+        "url": battleAPIBaseURL + "/${:gameid}/game_state"
       },
       "isResult": false
     },
@@ -106,7 +107,7 @@ export const graphChat: GraphData = {
         "method": "POST"
       },
       "inputs": {
-        "url": "https://aq-world.singularitybattlequest.club/api/${:gameid}/reveal_cell",
+        "url": battleAPIBaseURL + "/${:gameid}/reveal_cell",
         "body": {
           "row": ":args.row",
           "col": ":args.col"

--- a/packages/grapys-vue/src/graph/battle_player_prod.ts
+++ b/packages/grapys-vue/src/graph/battle_player_prod.ts
@@ -1,0 +1,612 @@
+import { GraphData } from "graphai";
+export const graphChat: GraphData = {
+  "version": 0.5,
+  "nodes": {
+    "gameid": {
+      "value": "123aaa"
+    },
+    "bot": {
+      "agent": "copyAgent",
+      "params": {
+        "isResult": true
+      },
+      "inputs": {
+        "message": {
+          "role": "bot",
+          "content": ":gameState.board"
+        }
+      },
+      "isResult": true
+    },
+    "llm": {
+      "agent": "openAIAgent",
+      "params": {
+        "stream": true,
+        "isResult": true,
+        "temperature": 0.7
+      },
+      "inputs": {
+        "prompt": ":merge.array",
+        "tools": ":tools"
+      },
+      "isResult": true
+    },
+    "merge": {
+      "agent": "copyAgent",
+      "params": {},
+      "inputs": {
+        "array": [
+          ":prompt",
+          ":json.text"
+        ]
+      },
+      "isResult": false
+    },
+    "prompt": {
+      "value": "You are the red team.\nFrom the given hints, provide the next candidates for code names."
+    },
+    "json": {
+      "agent": "jsonParserAgent",
+      "params": {},
+      "inputs": {
+        "data": ":gameState.board"
+      },
+      "isResult": false
+    },
+    "gameState": {
+      "agent": "vanillaFetchAgent",
+      "params": {},
+      "inputs": {
+        "url": "https://aq-world.singularitybattlequest.club/api/${:gameid}/game_state"
+      },
+      "isResult": false
+    },
+    "tools": {
+      "value": [
+        {
+          "type": "function",
+          "function": {
+            "name": "ChoiceCell",
+            "description": "post cell ",
+            "parameters": {
+              "type": "object",
+              "required": [
+                "row",
+                "col"
+              ],
+              "properties": {
+                "row": {
+                  "type": "integer"
+                },
+                "col": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "toolsBot": {
+      "agent": "copyAgent",
+      "params": {
+        "isResult": true
+      },
+      "inputs": {
+        "message": {
+          "role": "bot",
+          "content": ":llm.tool"
+        }
+      },
+      "isResult": true
+    },
+    "cell": {
+      "agent": "vanillaFetchAgent",
+      "params": {
+        "method": "POST"
+      },
+      "inputs": {
+        "url": "https://aq-world.singularitybattlequest.club/api/${:gameid}/reveal_cell",
+        "body": {
+          "row": ":args.row",
+          "col": ":args.col"
+        }
+      },
+      "isResult": false
+    },
+    "args": {
+      "agent": "copyAgent",
+      "params": {
+        "namedKey": "arguments"
+      },
+      "inputs": {
+        "arguments": ":llm.tool.arguments"
+      },
+      "isResult": false
+    }
+  },
+  "metadata": {
+    "data": {
+      "nodes": [
+        {
+          "data": {
+            "value": "123aaa",
+            "staticNodeType": "text"
+          },
+          "nodeId": "gameid",
+          "type": "static",
+          "position": {
+            "x": 22.983502015446106,
+            "y": 145.29806604095972,
+            "width": 144,
+            "height": 242,
+            "inputCenters": [
+              56
+            ],
+            "outputCenters": [
+              36
+            ]
+          }
+        },
+        {
+          "data": {
+            "agent": "copyAgent",
+            "guiAgentId": "dataToChatBotAgent",
+            "params": {
+              "isResult": true
+            }
+          },
+          "nodeId": "bot",
+          "type": "computed",
+          "position": {
+            "x": 244.81203211878255,
+            "y": 707.920187424845,
+            "width": 144,
+            "height": 168,
+            "inputCenters": [
+              76
+            ],
+            "outputCenters": [
+              56
+            ]
+          }
+        },
+        {
+          "data": {
+            "agent": "openAIAgent",
+            "guiAgentId": "openAIAgent",
+            "params": {
+              "stream": true,
+              "isResult": true,
+              "temperature": 0.7
+            }
+          },
+          "nodeId": "llm",
+          "type": "computed",
+          "position": {
+            "x": 648.9245138430258,
+            "y": 344.53342756634777,
+            "width": 144,
+            "height": 636,
+            "inputCenters": [
+              156,
+              172,
+              188,
+              204
+            ],
+            "outputCenters": [
+              56,
+              72,
+              88,
+              104,
+              120,
+              136
+            ]
+          }
+        },
+        {
+          "data": {
+            "agent": "copyAgent",
+            "guiAgentId": "itemToArrayAgent",
+            "params": {}
+          },
+          "nodeId": "merge",
+          "type": "computed",
+          "position": {
+            "x": 458.34420354120834,
+            "y": 459.63439085065426,
+            "width": 144,
+            "height": 168,
+            "inputCenters": [
+              76,
+              92,
+              108,
+              124
+            ],
+            "outputCenters": [
+              56
+            ]
+          }
+        },
+        {
+          "data": {
+            "value": "You are the red team.\nFrom the given hints, provide the next candidates for code names.",
+            "staticNodeType": "text"
+          },
+          "nodeId": "prompt",
+          "type": "static",
+          "position": {
+            "x": 242.79657459639623,
+            "y": 201.25551654363744,
+            "width": 144,
+            "height": 242,
+            "inputCenters": [
+              56
+            ],
+            "outputCenters": [
+              36
+            ]
+          }
+        },
+        {
+          "data": {
+            "agent": "jsonParserAgent",
+            "guiAgentId": "dataToJsonString",
+            "params": {}
+          },
+          "nodeId": "json",
+          "type": "computed",
+          "position": {
+            "x": 244.57405458719063,
+            "y": 492.3930946463338,
+            "width": 144,
+            "height": 120,
+            "inputCenters": [
+              76
+            ],
+            "outputCenters": [
+              56
+            ]
+          }
+        },
+        {
+          "data": {
+            "agent": "vanillaFetchAgent",
+            "guiAgentId": "gameStateAgent",
+            "params": {}
+          },
+          "nodeId": "gameState",
+          "type": "computed",
+          "position": {
+            "x": 35.940258126992774,
+            "y": 512.992292682572,
+            "width": 144,
+            "height": 216,
+            "inputCenters": [
+              172
+            ],
+            "outputCenters": [
+              56,
+              72,
+              88,
+              104,
+              120,
+              136,
+              152
+            ]
+          }
+        },
+        {
+          "data": {
+            "value": [
+              {
+                "type": "function",
+                "function": {
+                  "name": "ChoiceCell",
+                  "description": "post cell ",
+                  "parameters": {
+                    "type": "object",
+                    "required": [
+                      "row",
+                      "col"
+                    ],
+                    "properties": {
+                      "row": {
+                        "type": "integer"
+                      },
+                      "col": {
+                        "type": "integer"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "staticNodeType": "data"
+          },
+          "nodeId": "tools",
+          "type": "static",
+          "position": {
+            "x": 432.5870995025862,
+            "y": 706.8466972803519,
+            "width": 144,
+            "height": 266,
+            "inputCenters": [
+              56
+            ],
+            "outputCenters": [
+              36
+            ]
+          }
+        },
+        {
+          "data": {
+            "agent": "copyAgent",
+            "guiAgentId": "dataToChatBotAgent",
+            "params": {
+              "isResult": true
+            }
+          },
+          "nodeId": "toolsBot",
+          "type": "computed",
+          "position": {
+            "x": 859.4810309542365,
+            "y": 684.2704454733152,
+            "width": 144,
+            "height": 168,
+            "inputCenters": [
+              76
+            ],
+            "outputCenters": [
+              56
+            ]
+          }
+        },
+        {
+          "data": {
+            "agent": "vanillaFetchAgent",
+            "guiAgentId": "revealCell",
+            "params": {
+              "method": "POST"
+            }
+          },
+          "nodeId": "cell",
+          "type": "computed",
+          "position": {
+            "x": 1059.8233867837166,
+            "y": 65.04566659853708,
+            "width": 144,
+            "height": 200,
+            "inputCenters": [
+              124,
+              140,
+              156
+            ],
+            "outputCenters": [
+              56,
+              72,
+              88,
+              104
+            ]
+          }
+        },
+        {
+          "data": {
+            "agent": "copyAgent",
+            "guiAgentId": "arguments2cellPost",
+            "params": {
+              "namedKey": "arguments"
+            }
+          },
+          "nodeId": "args",
+          "type": "computed",
+          "position": {
+            "x": 848.5593537049091,
+            "y": 354.7611982874075,
+            "width": 144,
+            "height": 136,
+            "inputCenters": [
+              92
+            ],
+            "outputCenters": [
+              56,
+              72
+            ]
+          }
+        }
+      ],
+      "edges": [
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "merge",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "llm",
+            "index": 1,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "gameid",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "gameState",
+            "index": 0,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "gameState",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "json",
+            "index": 0,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "tools",
+            "index": 0,
+            "direction": "inbound"
+          },
+          "target": {
+            "nodeId": "llm",
+            "index": 3
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "llm",
+            "index": 3
+          },
+          "target": {
+            "nodeId": "toolsBot",
+            "index": 0,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "llm",
+            "index": 3
+          },
+          "target": {
+            "nodeId": "args",
+            "index": 0,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "args",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "cell",
+            "index": 1,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "args",
+            "index": 1
+          },
+          "target": {
+            "nodeId": "cell",
+            "index": 2,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "gameid",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "cell",
+            "index": 0,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "gameState",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "bot",
+            "index": 0,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "json",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "merge",
+            "index": 1,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "prompt",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "merge",
+            "index": 0,
+            "direction": "outbound"
+          }
+        }
+      ],
+      "loop": {
+        "loopType": "none"
+      }
+    },
+    "forNested": {
+      "output": {
+        "bot_message": ".bot.message",
+        "llm_message": ".llm.message",
+        "llm_messages": ".llm.messages",
+        "llm_text": ".llm.text",
+        "llm_tool": ".llm.tool",
+        "llm_tool_calls": ".llm.tool_calls",
+        "llm_metadata": ".llm.metadata",
+        "toolsBot_message": ".toolsBot.message"
+      },
+      "outputs": [
+        {
+          "name": "bot_message"
+        },
+        {
+          "name": "llm_message",
+          "type": "message"
+        },
+        {
+          "name": "llm_messages"
+        },
+        {
+          "name": "llm_text",
+          "type": "text"
+        },
+        {
+          "name": "llm_tool",
+          "type": "data"
+        },
+        {
+          "name": "llm_tool_calls",
+          "type": "array"
+        },
+        {
+          "name": "llm_metadata",
+          "type": "data"
+        },
+        {
+          "name": "toolsBot_message"
+        }
+      ]
+    }
+  }
+};

--- a/packages/grapys-vue/src/graph/battle_register_prod.ts
+++ b/packages/grapys-vue/src/graph/battle_register_prod.ts
@@ -1,0 +1,184 @@
+import { GraphData } from "graphai";
+export const graphChat: GraphData = {
+  "version": 0.5,
+  "nodes": {
+    "register": {
+      "agent": "vanillaFetchAgent",
+      "params": {
+        "url": "https://aq-world.singularitybattlequest.club/api/register",
+        "method": "POST"
+      },
+      "inputs": {
+        "body": {
+          "game_id": ":gameid",
+          "team": ":team"
+        }
+      },
+      "isResult": false
+    },
+    "gameid": {
+      "value": "123aaa"
+    },
+    "team": {
+      "value": "red"
+    },
+    "bot": {
+      "agent": "copyAgent",
+      "params": {
+        "isResult": true
+      },
+      "inputs": {
+        "message": {
+          "role": "bot",
+          "content": ":register.status"
+        }
+      },
+      "isResult": true
+    }
+  },
+  "metadata": {
+    "data": {
+      "nodes": [
+        {
+          "data": {
+            "agent": "vanillaFetchAgent",
+            "guiAgentId": "gameRegister",
+            "params": {
+              "url": "https://dev.aq-world.singularitybattlequest.club/api/register",
+              "method": "POST"
+            }
+          },
+          "nodeId": "register",
+          "type": "computed",
+          "position": {
+            "x": 264.40842059070985,
+            "y": 187.36026804684178,
+            "width": 144,
+            "height": 136,
+            "inputCenters": [
+              76,
+              92
+            ],
+            "outputCenters": [
+              56
+            ]
+          }
+        },
+        {
+          "data": {
+            "value": "123aaa",
+            "staticNodeType": "text"
+          },
+          "nodeId": "gameid",
+          "type": "static",
+          "position": {
+            "x": 40.983502015446106,
+            "y": 185.29806604095972,
+            "width": 144,
+            "height": 243,
+            "inputCenters": [
+              56
+            ],
+            "outputCenters": [
+              36
+            ]
+          }
+        },
+        {
+          "data": {
+            "value": "red",
+            "staticNodeType": "text"
+          },
+          "nodeId": "team",
+          "type": "static",
+          "position": {
+            "x": 42.00856458618915,
+            "y": 453.5002510361081,
+            "width": 144,
+            "height": 243,
+            "inputCenters": [
+              56
+            ],
+            "outputCenters": [
+              36
+            ]
+          }
+        },
+        {
+          "data": {
+            "agent": "copyAgent",
+            "guiAgentId": "dataToChatBotAgent",
+            "params": {
+              "isResult": true
+            }
+          },
+          "nodeId": "bot",
+          "type": "computed",
+          "position": {
+            "x": 513.8120321187824,
+            "y": 166.92018742484504,
+            "width": 144,
+            "height": 168,
+            "inputCenters": [
+              76
+            ],
+            "outputCenters": [
+              56
+            ]
+          }
+        }
+      ],
+      "edges": [
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "team",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "register",
+            "index": 1,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "gameid",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "register",
+            "index": 0,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "register",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "bot",
+            "index": 0,
+            "direction": "outbound"
+          }
+        }
+      ],
+      "loop": {
+        "loopType": "none"
+      }
+    },
+    "forNested": {
+      "output": {
+        "bot_message": ".bot.message"
+      },
+      "outputs": [
+        {
+          "name": "bot_message"
+        }
+      ]
+    }
+  }
+};

--- a/packages/grapys-vue/src/graph/battle_register_prod.ts
+++ b/packages/grapys-vue/src/graph/battle_register_prod.ts
@@ -1,11 +1,12 @@
 import { GraphData } from "graphai";
+import { battleAPIBaseURL } from "../config/project";
 export const graphChat: GraphData = {
   "version": 0.5,
   "nodes": {
     "register": {
       "agent": "vanillaFetchAgent",
       "params": {
-        "url": "https://aq-world.singularitybattlequest.club/api/register",
+        "url": battleAPIBaseURL + "/register",
         "method": "POST"
       },
       "inputs": {
@@ -44,7 +45,7 @@ export const graphChat: GraphData = {
             "agent": "vanillaFetchAgent",
             "guiAgentId": "gameRegister",
             "params": {
-              "url": "https://dev.aq-world.singularitybattlequest.club/api/register",
+              "url": battleAPIBaseURL + "/register",
               "method": "POST"
             }
           },

--- a/packages/grapys-vue/src/graph/battle_spy_tools_prod.ts
+++ b/packages/grapys-vue/src/graph/battle_spy_tools_prod.ts
@@ -1,0 +1,653 @@
+import { GraphData } from "graphai";
+export const graphChat: GraphData = {
+  "version": 0.5,
+  "nodes": {
+    "gameid": {
+      "value": "123aaa"
+    },
+    "bot": {
+      "agent": "copyAgent",
+      "params": {
+        "isResult": true
+      },
+      "inputs": {
+        "message": {
+          "role": "bot",
+          "content": ":spy.board"
+        }
+      },
+      "isResult": true
+    },
+    "spy": {
+      "agent": "vanillaFetchAgent",
+      "params": {},
+      "inputs": {
+        "url": "https://aq-world.singularitybattlequest.club/api/${:gameid}/spymaster_state"
+      },
+      "isResult": false
+    },
+    "llm": {
+      "agent": "openAIAgent",
+      "params": {
+        "stream": true,
+        "isResult": true,
+        "temperature": 0.7
+      },
+      "inputs": {
+        "prompt": ":merge.array",
+        "tools": ":toolsData"
+      },
+      "isResult": true
+    },
+    "merge": {
+      "agent": "copyAgent",
+      "params": {},
+      "inputs": {
+        "array": [
+          ":prompt",
+          ":json.text"
+        ]
+      },
+      "isResult": false
+    },
+    "prompt": {
+      "value": "You are the red team.\nGive hints for the code names from the given JSON data."
+    },
+    "message": {
+      "agent": "copyAgent",
+      "params": {
+        "isResult": true
+      },
+      "inputs": {
+        "message": {
+          "role": "bot",
+          "content": ":llm.text"
+        }
+      },
+      "isResult": true
+    },
+    "json": {
+      "agent": "jsonParserAgent",
+      "params": {},
+      "inputs": {
+        "data": ":spy.board"
+      },
+      "isResult": false
+    },
+    "toolsBot": {
+      "agent": "copyAgent",
+      "params": {
+        "isResult": true
+      },
+      "inputs": {
+        "message": {
+          "role": "bot",
+          "content": ":arg.hint"
+        }
+      },
+      "isResult": true
+    },
+    "toolsData": {
+      "value": [
+        {
+          "type": "function",
+          "function": {
+            "name": "spyHint",
+            "description": "post spy hint",
+            "parameters": {
+              "type": "object",
+              "properties": {
+                "hint": {
+                  "type": "string",
+                  "description": "hint message"
+                },
+                "guess_count": {
+                  "type": "number",
+                  "description": "number of guess"
+                }
+              },
+              "required": [
+                "hint",
+                "guess_count"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "arg": {
+      "agent": "copyAgent",
+      "params": {
+        "namedKey": "arguments"
+      },
+      "inputs": {
+        "arguments": ":llm.tool.arguments"
+      },
+      "isResult": false
+    },
+    "submit": {
+      "agent": "vanillaFetchAgent",
+      "params": {},
+      "inputs": {
+        "url": "https://aq-world.singularitybattlequest.club/api/${:gameid}/submit_hint",
+        "body": {
+          "hint": ":arg.hint",
+          "guess_count": ":arg.guess_count"
+        }
+      },
+      "isResult": false
+    }
+  },
+  "metadata": {
+    "data": {
+      "nodes": [
+        {
+          "data": {
+            "value": "123aaa",
+            "staticNodeType": "text"
+          },
+          "nodeId": "gameid",
+          "type": "static",
+          "position": {
+            "x": 25.983502015446106,
+            "y": 151.29806604095972,
+            "width": 144,
+            "height": 243,
+            "inputCenters": [
+              56
+            ],
+            "outputCenters": [
+              36
+            ]
+          }
+        },
+        {
+          "data": {
+            "agent": "copyAgent",
+            "guiAgentId": "dataToChatBotAgent",
+            "params": {
+              "isResult": true
+            }
+          },
+          "nodeId": "bot",
+          "type": "computed",
+          "position": {
+            "x": 289.81203211878244,
+            "y": 714.920187424845,
+            "width": 144,
+            "height": 168,
+            "inputCenters": [
+              76
+            ],
+            "outputCenters": [
+              56
+            ]
+          }
+        },
+        {
+          "data": {
+            "agent": "vanillaFetchAgent",
+            "guiAgentId": "spyMasterAgent",
+            "params": {}
+          },
+          "nodeId": "spy",
+          "type": "computed",
+          "position": {
+            "x": 45.01068422496144,
+            "y": 539.7067886578145,
+            "width": 144,
+            "height": 120,
+            "inputCenters": [
+              76
+            ],
+            "outputCenters": [
+              56
+            ]
+          }
+        },
+        {
+          "data": {
+            "agent": "openAIAgent",
+            "guiAgentId": "openAIAgent",
+            "params": {
+              "stream": true,
+              "isResult": true,
+              "temperature": 0.7
+            }
+          },
+          "nodeId": "llm",
+          "type": "computed",
+          "position": {
+            "x": 651.9245138430258,
+            "y": 305.53342756634777,
+            "width": 144,
+            "height": 636,
+            "inputCenters": [
+              156,
+              172,
+              188,
+              204
+            ],
+            "outputCenters": [
+              56,
+              72,
+              88,
+              104,
+              120,
+              136
+            ]
+          }
+        },
+        {
+          "data": {
+            "agent": "copyAgent",
+            "guiAgentId": "itemToArrayAgent",
+            "params": {}
+          },
+          "nodeId": "merge",
+          "type": "computed",
+          "position": {
+            "x": 456.34420354120834,
+            "y": 428.63439085065426,
+            "width": 144,
+            "height": 168,
+            "inputCenters": [
+              76,
+              92,
+              108,
+              124
+            ],
+            "outputCenters": [
+              56
+            ]
+          }
+        },
+        {
+          "data": {
+            "value": "You are the red team.\nGive hints for the code names from the given JSON data.",
+            "staticNodeType": "text"
+          },
+          "nodeId": "prompt",
+          "type": "static",
+          "position": {
+            "x": 221.79657459639623,
+            "y": 240.25551654363744,
+            "width": 144,
+            "height": 243,
+            "inputCenters": [
+              56
+            ],
+            "outputCenters": [
+              36
+            ]
+          }
+        },
+        {
+          "data": {
+            "agent": "copyAgent",
+            "guiAgentId": "dataToChatBotAgent",
+            "params": {
+              "isResult": true
+            }
+          },
+          "nodeId": "message",
+          "type": "computed",
+          "position": {
+            "x": 829.2313530368328,
+            "y": 229.07262572529368,
+            "width": 144,
+            "height": 168,
+            "inputCenters": [
+              76
+            ],
+            "outputCenters": [
+              56
+            ]
+          }
+        },
+        {
+          "data": {
+            "agent": "jsonParserAgent",
+            "guiAgentId": "dataToJsonString",
+            "params": {}
+          },
+          "nodeId": "json",
+          "type": "computed",
+          "position": {
+            "x": 233.57405458719063,
+            "y": 519.3930946463338,
+            "width": 144,
+            "height": 120,
+            "inputCenters": [
+              76
+            ],
+            "outputCenters": [
+              56
+            ]
+          }
+        },
+        {
+          "data": {
+            "agent": "copyAgent",
+            "guiAgentId": "dataToChatBotAgent",
+            "params": {
+              "isResult": true
+            }
+          },
+          "nodeId": "toolsBot",
+          "type": "computed",
+          "position": {
+            "x": 979.2916891280795,
+            "y": 679.137032070028,
+            "width": 144,
+            "height": 168,
+            "inputCenters": [
+              76
+            ],
+            "outputCenters": [
+              56
+            ]
+          }
+        },
+        {
+          "data": {
+            "value": [
+              {
+                "type": "function",
+                "function": {
+                  "name": "spyHint",
+                  "description": "post spy hint",
+                  "parameters": {
+                    "type": "object",
+                    "properties": {
+                      "hint": {
+                        "type": "string",
+                        "description": "hint message"
+                      },
+                      "guess_count": {
+                        "type": "number",
+                        "description": "number of guess"
+                      }
+                    },
+                    "required": [
+                      "hint",
+                      "guess_count"
+                    ]
+                  }
+                }
+              }
+            ],
+            "staticNodeType": "data"
+          },
+          "nodeId": "toolsData",
+          "type": "static",
+          "position": {
+            "x": 454.50456560391444,
+            "y": 618.6718665921711,
+            "width": 144,
+            "height": 267,
+            "inputCenters": [
+              56
+            ],
+            "outputCenters": [
+              36
+            ]
+          }
+        },
+        {
+          "data": {
+            "agent": "copyAgent",
+            "guiAgentId": "arguments2hintPost",
+            "params": {
+              "namedKey": "arguments"
+            }
+          },
+          "nodeId": "arg",
+          "type": "computed",
+          "position": {
+            "x": 838.1263516798331,
+            "y": 500.00622874524447,
+            "width": 144,
+            "height": 136,
+            "inputCenters": [
+              92
+            ],
+            "outputCenters": [
+              56,
+              72
+            ]
+          }
+        },
+        {
+          "data": {
+            "agent": "vanillaFetchAgent",
+            "guiAgentId": "submitHintAgent",
+            "params": {}
+          },
+          "nodeId": "submit",
+          "type": "computed",
+          "position": {
+            "x": 1114.7906895487015,
+            "y": 129.06052192260245,
+            "width": 144,
+            "height": 136,
+            "inputCenters": [
+              60,
+              76,
+              92
+            ],
+            "outputCenters": []
+          }
+        }
+      ],
+      "edges": [
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "gameid",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "spy",
+            "index": 0,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "spy",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "bot",
+            "index": 0,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "llm",
+            "index": 2
+          },
+          "target": {
+            "nodeId": "message",
+            "index": 0,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "spy",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "json",
+            "index": 0,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "merge",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "llm",
+            "index": 1,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "toolsData",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "llm",
+            "index": 3,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "llm",
+            "index": 3
+          },
+          "target": {
+            "nodeId": "arg",
+            "index": 0,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "arg",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "toolsBot",
+            "index": 0,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "arg",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "submit",
+            "index": 1,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "arg",
+            "index": 1
+          },
+          "target": {
+            "nodeId": "submit",
+            "index": 2,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "gameid",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "submit",
+            "index": 0,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "json",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "merge",
+            "index": 1,
+            "direction": "outbound"
+          }
+        },
+        {
+          "type": "edge",
+          "source": {
+            "nodeId": "prompt",
+            "index": 0
+          },
+          "target": {
+            "nodeId": "merge",
+            "index": 0,
+            "direction": "outbound"
+          }
+        }
+      ],
+      "loop": {
+        "loopType": "none"
+      }
+    },
+    "forNested": {
+      "output": {
+        "bot_message": ".bot.message",
+        "llm_message": ".llm.message",
+        "llm_messages": ".llm.messages",
+        "llm_text": ".llm.text",
+        "llm_tool": ".llm.tool",
+        "llm_tool_calls": ".llm.tool_calls",
+        "llm_metadata": ".llm.metadata",
+        "message_message": ".message.message",
+        "toolsBot_message": ".toolsBot.message"
+      },
+      "outputs": [
+        {
+          "name": "bot_message"
+        },
+        {
+          "name": "llm_message",
+          "type": "message"
+        },
+        {
+          "name": "llm_messages"
+        },
+        {
+          "name": "llm_text",
+          "type": "text"
+        },
+        {
+          "name": "llm_tool",
+          "type": "data"
+        },
+        {
+          "name": "llm_tool_calls",
+          "type": "array"
+        },
+        {
+          "name": "llm_metadata",
+          "type": "data"
+        },
+        {
+          "name": "message_message"
+        },
+        {
+          "name": "toolsBot_message"
+        }
+      ]
+    }
+  }
+};

--- a/packages/grapys-vue/src/graph/battle_spy_tools_prod.ts
+++ b/packages/grapys-vue/src/graph/battle_spy_tools_prod.ts
@@ -1,4 +1,5 @@
 import { GraphData } from "graphai";
+import { battleAPIBaseURL } from "../config/project";
 export const graphChat: GraphData = {
   "version": 0.5,
   "nodes": {
@@ -22,7 +23,7 @@ export const graphChat: GraphData = {
       "agent": "vanillaFetchAgent",
       "params": {},
       "inputs": {
-        "url": "https://aq-world.singularitybattlequest.club/api/${:gameid}/spymaster_state"
+        "url": battleAPIBaseURL + "/${:gameid}/spymaster_state"
       },
       "isResult": false
     },
@@ -129,7 +130,7 @@ export const graphChat: GraphData = {
       "agent": "vanillaFetchAgent",
       "params": {},
       "inputs": {
-        "url": "https://aq-world.singularitybattlequest.club/api/${:gameid}/submit_hint",
+        "url": battleAPIBaseURL + "/${:gameid}/submit_hint",
         "body": {
           "hint": ":arg.hint",
           "guess_count": ":arg.guess_count"

--- a/packages/grapys-vue/src/graph/index.ts
+++ b/packages/grapys-vue/src/graph/index.ts
@@ -5,6 +5,9 @@ import { graphChat as graphBattleRegister } from "./battle_register";
 import { graphChat as graphBattleSpy } from "./battle_spy";
 import { graphChat as graphBattleSpyTools } from "./battle_spy_tools";
 import { graphChat as graphBattlePlayer } from "./battle_player";
+import { graphChat as graphBattleRegisterProd } from "./battle_register_prod";
+import { graphChat as graphBattleSpyToolsProd } from "./battle_spy_tools_prod";
+import { graphChat as graphBattlePlayerProd } from "./battle_player_prod";
 
 import { graphChat as graphChatOpenAI } from "../graph/chat";
 import { graphChat as graphChatOpenAI2 } from "../graph/chat2";
@@ -26,6 +29,9 @@ export const graphs: NestedGraphList = [
   { name: "BattleSpy", graph: graphBattleSpy, id: "22222222" },
   { name: "BattleSpy(Tools)", graph: graphBattleSpyTools, id: "33333333" },
   { name: "BattlePlayer", graph: graphBattlePlayer, id: "44444" },
+  { name: "BattleRegister(Prod)", graph: graphBattleRegisterProd, id: "55555555" },
+  { name: "BattleSpy(Tools,Prod)", graph: graphBattleSpyToolsProd, id: "66666666" },
+  { name: "BattlePlayer(Prod)", graph: graphBattlePlayerProd, id: "77777777" },
   // { name: "Chat(WebLLM)", graph: graphChatTinySwallow, id: "pkrDLhdU5zUb77mN" },
   { name: "Chat(Alone)", graph: graphChatAlone, id: "dJ5cw36SevqDkxFN" },
   { name: "Chat(OpenAI)", graph: graphChatOpenAI2, id: "V474FFCTgdSbFkgN" },

--- a/packages/grapys-vue/src/graph/index.ts
+++ b/packages/grapys-vue/src/graph/index.ts
@@ -25,13 +25,13 @@ import { graphData as graphDataImageGenerator } from "../graph/image_generator";
 import { graphData as graphDataFetch } from "../graph/fetch";
 
 export const graphs: NestedGraphList = [
-  { name: "BattleRegister", graph: graphBattleRegister, id: "11111111" },
-  { name: "BattleSpy", graph: graphBattleSpy, id: "22222222" },
-  { name: "BattleSpy(Tools)", graph: graphBattleSpyTools, id: "33333333" },
-  { name: "BattlePlayer", graph: graphBattlePlayer, id: "44444" },
-  { name: "BattleRegister(Prod)", graph: graphBattleRegisterProd, id: "55555555" },
-  { name: "BattleSpy(Tools,Prod)", graph: graphBattleSpyToolsProd, id: "66666666" },
-  { name: "BattlePlayer(Prod)", graph: graphBattlePlayerProd, id: "77777777" },
+  //{ name: "BattleRegister", graph: graphBattleRegister, id: "11111111" },
+  //{ name: "BattleSpy", graph: graphBattleSpy, id: "22222222" },
+  //{ name: "BattleSpy(Tools)", graph: graphBattleSpyTools, id: "33333333" },
+  //{ name: "BattlePlayer", graph: graphBattlePlayer, id: "44444" },
+  { name: "BattleRegister", graph: graphBattleRegisterProd, id: "55555555" },
+  { name: "BattleSpy(Tools)", graph: graphBattleSpyToolsProd, id: "66666666" },
+  { name: "BattlePlayer", graph: graphBattlePlayerProd, id: "77777777" },
   // { name: "Chat(WebLLM)", graph: graphChatTinySwallow, id: "pkrDLhdU5zUb77mN" },
   { name: "Chat(Alone)", graph: graphChatAlone, id: "dJ5cw36SevqDkxFN" },
   { name: "Chat(OpenAI)", graph: graphChatOpenAI2, id: "V474FFCTgdSbFkgN" },


### PR DESCRIPTION
- 設定ファイルに API URL 追加
- prod 向けの GraphData 更新および prod のみ表示
- prod 向けのGraphData はノードの配置を変更、API URLを開発、本番で分けて設定