### PR TITLE
Node2: Editor panel separated node UI

### DIFF
--- a/packages/grapys-vue/src/views/GUI.vue
+++ b/packages/grapys-vue/src/views/GUI.vue
@@ -38,8 +38,8 @@ export default defineComponent({
     const store = useStore();
     const contextEdgeMenu = ref();
     const contextNodeMenu = ref();
-    const showNodeEditor = ref(false);
-    const selectedNodeIndex = ref(0);
+    const selectedNodeIndex = ref<number | null>(null);
+    const isNodeEditorOpen = computed(() => selectedNodeIndex.value !== null);
     const panelKey = ref(0);
     const mainContainer = ref();
     store.initFromGraphData(graphChat);
@@ -95,13 +95,10 @@ export default defineComponent({
       contextNodeMenu.value.openMenu(event, rect, nodeIndex);
     };
     const openNodeEditor = (_event: MouseEvent, nodeIndex: number) => {
-      // 同じノードを連続クリックした場合は再マウントしない
-      const isSameNode = selectedNodeIndex.value === nodeIndex;
+      // remount only if different node is clicked
+      if (selectedNodeIndex.value === nodeIndex) return;
       selectedNodeIndex.value = nodeIndex;
-      if (!isSameNode || !showNodeEditor.value) {
-        panelKey.value += 1;
-      }
-      showNodeEditor.value = true;
+      panelKey.value += 1;
     };
 
     const showJsonView = ref(false);
@@ -135,8 +132,8 @@ export default defineComponent({
       showJsonView,
       showChat,
       mainContainer,
-      showNodeEditor,
       selectedNodeIndex,
+      isNodeEditorOpen,
       panelKey,
 
       handleNodeDragStart,
@@ -233,11 +230,12 @@ export default defineComponent({
             <GraphRunner :class="{ hidden: !showChat }" :graph-data="store.graphData" :is-open="showChat" @close="showChat = false" />
             <NodeEditorPanel
               :key="panelKey"
-              :is-open="showNodeEditor"
-              :node-index="selectedNodeIndex"
-              @close="showNodeEditor = false"
-              @update-static-node-value="(v: UpdateStaticValue) => updateStaticNodeValue(selectedNodeIndex, v, true)"
-              @update-nested-graph="(v: UpdateStaticValue) => updateNestedGraph(selectedNodeIndex, v)"
+              :is-open="isNodeEditorOpen"
+              v-if="isNodeEditorOpen"
+              :node-index="selectedNodeIndex as number"
+              @close="selectedNodeIndex = null"
+              @update-static-node-value="(v: UpdateStaticValue) => updateStaticNodeValue(selectedNodeIndex as number, v, true)"
+              @update-nested-graph="(v: UpdateStaticValue) => updateNestedGraph(selectedNodeIndex as number, v)"
             />
           </div>
         </div>

--- a/packages/grapys-vue/src/views/GUI.vue
+++ b/packages/grapys-vue/src/views/GUI.vue
@@ -1,6 +1,8 @@
 <script lang="ts">
 import { defineComponent, computed, onMounted, ref } from "vue";
 import Node from "./Node.vue";
+import Node2 from "./Node2.vue";
+import NodeEditorPanel from "./NodeEditorPanel.vue";
 import Edge from "./Edge.vue";
 import Loop from "./Loop.vue";
 
@@ -25,10 +27,12 @@ export default defineComponent({
   components: {
     SideMenu,
     Node,
+    Node2,
     Edge,
     Loop,
     ContextEdgeMenu,
     ContextNodeMenu,
+    NodeEditorPanel,
     GraphRunner,
     JsonViewer,
   },
@@ -36,6 +40,9 @@ export default defineComponent({
     const store = useStore();
     const contextEdgeMenu = ref();
     const contextNodeMenu = ref();
+    const showNodeEditor = ref(false);
+    const selectedNodeIndex = ref(0);
+    const panelKey = ref(0);
     const mainContainer = ref();
     store.initFromGraphData(graphChat);
 
@@ -89,6 +96,15 @@ export default defineComponent({
       const rect = svgRef.value.getBoundingClientRect();
       contextNodeMenu.value.openMenu(event, rect, nodeIndex);
     };
+    const openNodeEditor = (_event: MouseEvent, nodeIndex: number) => {
+      // 同じノードを連続クリックした場合は再マウントしない
+      const isSameNode = selectedNodeIndex.value === nodeIndex;
+      selectedNodeIndex.value = nodeIndex;
+      if (!isSameNode || !showNodeEditor.value) {
+        panelKey.value++;
+      }
+      showNodeEditor.value = true;
+    };
 
     const showJsonView = ref(false);
     const showChat = ref(false);
@@ -113,6 +129,7 @@ export default defineComponent({
       contextNodeMenu,
       openEdgeMenu,
       openNodeMenu,
+      openNodeEditor,
       closeMenu,
 
       edgeConnectable,
@@ -120,6 +137,9 @@ export default defineComponent({
       showJsonView,
       showChat,
       mainContainer,
+      showNodeEditor,
+      selectedNodeIndex,
+      panelKey,
 
       handleNodeDragStart,
       handleNodeDragEnd,
@@ -160,7 +180,7 @@ export default defineComponent({
                 :is-connectable="edgeConnectable"
               />
             </svg>
-            <Node
+            <Node2
               v-for="(node, index) in store.nodes"
               :key="[node.nodeId, index].join('-')"
               :node-index="index"
@@ -175,6 +195,7 @@ export default defineComponent({
               @new-edge="onNewEdge"
               @new-edge-end="onNewEdgeEnd"
               @open-node-menu="(event) => openNodeMenu(event, index)"
+              @open-node-edit-menu="(event) => openNodeEditor(event, index)"
               @node-drag-start="handleNodeDragStart"
               @node-drag-end="handleNodeDragEnd"
             />
@@ -212,6 +233,7 @@ export default defineComponent({
           <div class="flex flex-row items-start space-x-4">
             <JsonViewer v-if="showJsonView" :json-data="store.graphData" :is-open="showJsonView" @close="showJsonView = false" />
             <GraphRunner :class="{ hidden: !showChat }" :graph-data="store.graphData" :is-open="showChat" @close="showChat = false" />
+            <NodeEditorPanel :key="panelKey" :is-open="showNodeEditor" :node-index="selectedNodeIndex" @close="showNodeEditor = false" />
           </div>
         </div>
       </main>

--- a/packages/grapys-vue/src/views/GUI.vue
+++ b/packages/grapys-vue/src/views/GUI.vue
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { defineComponent, computed, onMounted, ref } from "vue";
-import Node from "./Node.vue";
 import Node2 from "./Node2.vue";
 import NodeEditorPanel from "./NodeEditorPanel.vue";
 import Edge from "./Edge.vue";
@@ -26,7 +25,6 @@ import { useStore } from "../store";
 export default defineComponent({
   components: {
     SideMenu,
-    Node,
     Node2,
     Edge,
     Loop,
@@ -101,7 +99,7 @@ export default defineComponent({
       const isSameNode = selectedNodeIndex.value === nodeIndex;
       selectedNodeIndex.value = nodeIndex;
       if (!isSameNode || !showNodeEditor.value) {
-        panelKey.value++;
+        panelKey.value += 1;
       }
       showNodeEditor.value = true;
     };
@@ -187,15 +185,15 @@ export default defineComponent({
               :node-data="node"
               :nearest-data="nearestData"
               :is-connectable="edgeConnectable"
-              @update-position="(pos) => updateNodePosition(index, pos)"
-              @update-static-node-value="(value) => updateStaticNodeValue(index, value, true)"
-              @update-nested-graph="(value) => updateNestedGraph(index, value)"
+              @update-position="(pos: NodePosition) => updateNodePosition(index, pos)"
+              @update-static-node-value="updateStaticNodeValue(index, $event, true)"
+              @update-nested-graph="updateNestedGraph(index, $event)"
               @save-position="saveNodePosition"
               @new-edge-start="onNewEdgeStart"
               @new-edge="onNewEdge"
               @new-edge-end="onNewEdgeEnd"
-              @open-node-menu="(event) => openNodeMenu(event, index)"
-              @open-node-edit-menu="(event) => openNodeEditor(event, index)"
+              @open-node-menu="(e: MouseEvent) => openNodeMenu(e, index)"
+              @open-node-edit-menu="(e: MouseEvent) => openNodeEditor(e, index)"
               @node-drag-start="handleNodeDragStart"
               @node-drag-end="handleNodeDragEnd"
             />
@@ -233,7 +231,14 @@ export default defineComponent({
           <div class="flex flex-row items-start space-x-4">
             <JsonViewer v-if="showJsonView" :json-data="store.graphData" :is-open="showJsonView" @close="showJsonView = false" />
             <GraphRunner :class="{ hidden: !showChat }" :graph-data="store.graphData" :is-open="showChat" @close="showChat = false" />
-            <NodeEditorPanel :key="panelKey" :is-open="showNodeEditor" :node-index="selectedNodeIndex" @close="showNodeEditor = false" />
+            <NodeEditorPanel
+              :key="panelKey"
+              :is-open="showNodeEditor"
+              :node-index="selectedNodeIndex"
+              @close="showNodeEditor = false"
+              @update-static-node-value="(v: UpdateStaticValue) => updateStaticNodeValue(selectedNodeIndex, v, true)"
+              @update-nested-graph="(v: UpdateStaticValue) => updateNestedGraph(selectedNodeIndex, v)"
+            />
           </div>
         </div>
       </main>

--- a/packages/grapys-vue/src/views/Node2.vue
+++ b/packages/grapys-vue/src/views/Node2.vue
@@ -1,0 +1,347 @@
+<template>
+  <div
+    class="absolute flex w-36 cursor-grab flex-col rounded-md text-center text-white select-none"
+    :class="nodeMainClass(expectNearNode, nodeData)"
+    :style="transform"
+    ref="thisRef"
+    @mousedown="onStartNode"
+    @touchstart="onStartNode"
+    @dblclick="(e) => openNodeMenu(e)"
+    @click="(e) => openNodeEditMenu(e)"
+  >
+    <div>
+      <div class="w-full rounded-t-md py-1 text-center leading-none" :class="nodeHeaderClass(expectNearNode, nodeData)">
+        {{ nodeData.nodeId }}
+      </div>
+      <div class="w-full py-1 text-center text-xs leading-none" v-if="nodeData.type === 'computed'" :class="nodeHeaderClass(expectNearNode, nodeData)">
+        {{ nodeData.data.guiAgentId?.replace(/Agent$/, "") }}
+      </div>
+    </div>
+    
+    <div class="mt-1 flex flex-col items-end">
+      <div v-for="(output, index) in outputs" :key="['out', output.name, index].join('-')" class="relative flex items-center" ref="outputsRef">
+        <span class="mr-2 text-xs whitespace-nowrap">{{ output.name }}</span>
+        <div
+          class="absolute right-[-10px] h-4 w-4 min-w-[12px] rounded-full"
+          :class="nodeOutputClass(isExpectNearButton('inbound', index), nodeData, isConnectable)"
+          @mousedown="(e) => onStartEdge(e, 'outbound', index)"
+          @touchstart="(e) => onStartEdge(e, 'outbound', index)"
+        ></div>
+      </div>
+    </div>
+
+    <div class="mt-1 mb-1 flex flex-col items-start">
+      <div
+        v-for="(input, index) in inputs"
+        :key="['in', input.name, index, nestedGraph?.id ?? ''].join('-')"
+        class="relative flex items-center"
+        ref="inputsRef"
+      >
+        <div
+          class="absolute left-[-10px] h-4 w-4 min-w-[12px] rounded-full"
+          :class="nodeInputClass(isExpectNearButton('outbound', index), nodeData, input as any, isConnectable)"
+          @mousedown="(e) => onStartEdge(e, 'inbound', index)"
+          @touchstart="(e) => onStartEdge(e, 'inbound', index)"
+        ></div>
+        <span class="ml-2 text-xs whitespace-nowrap">{{ input.name }}</span>
+      </div>
+    </div>
+    <div class="flex w-full flex-col gap-1 p-2">
+      <NodeResult :node-data="nodeData" />
+    </div>
+    
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, watchEffect, computed, PropType, onMounted, watch } from "vue";
+import { useStore } from "../store";
+import type { GUINodeData, GUINearestData, NewEdgeEventDirection } from "../utils/gui/type";
+import { getClientPos, getNodeSize, getTransformStyle, nestedGraphInputs } from "../utils/gui/utils";
+import { agentProfiles, staticNodeParams } from "../utils/gui/data";
+import { nodeMainClass, nodeHeaderClass, nodeOutputClass, nodeInputClass } from "../utils/gui/classUtils";
+// import { graphs } from "../graph";
+
+import NodeResult from "./NodeResult.vue";
+
+export default defineComponent({
+  name: "Node2",
+  components: {
+    NodeResult,
+  },
+  props: {
+    nodeData: {
+      type: Object as PropType<GUINodeData>,
+      required: true,
+    },
+    nearestData: {
+      type: Object as PropType<GUINearestData>,
+      default: undefined,
+    },
+    nodeIndex: {
+      type: Number,
+      required: true,
+    },
+    isConnectable: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
+  },
+  emits: [
+    "updatePosition",
+    "savePosition",
+    "newEdgeStart",
+    "newEdge",
+    "newEdgeEnd",
+    "updateStaticNodeValue",
+    "updateNestedGraph",
+    "openNodeMenu",
+    "openNodeEditMenu",
+    "nodeDragStart",
+    "nodeDragEnd",
+  ],
+  setup(props, ctx) {
+    const store = useStore();
+
+    const agentProfile = props.nodeData.type === "computed" ? agentProfiles[props.nodeData.data.guiAgentId ?? ""] : staticNodeParams;
+
+    const thisRef = ref<HTMLElement | null>(null);
+    const inputsRef = ref<HTMLElement[]>([]);
+    const outputsRef = ref<HTMLElement[]>([]);
+
+    const isDragging = ref(false);
+    const isNewEdge = ref(false);
+    const offset = ref({ x: 0, y: 0 });
+
+    const agentIndex = ref(props.nodeData.data.agentIndex ?? 0);
+    const nestedGraphIndex = ref(props.nodeData.data.nestedGraphIndex ?? 0);
+
+    const startPosition = { x: 0, y: 0 };
+    // If it moves only a little, the data will not be saved because it stack much more histories.
+    let deltaDistance = 0; // square
+    const deltaDistanceThredhold = 4;
+
+    const onStartNode = (event: MouseEvent | TouchEvent) => {
+      if (isNewEdge.value) {
+        return;
+      }
+      isDragging.value = true;
+      ctx.emit("nodeDragStart");
+      const { clientX, clientY } = getClientPos(event);
+      const position = props.nodeData.position;
+      offset.value.x = clientX - position.x;
+      offset.value.y = clientY - position.y;
+
+      // for update detection
+      startPosition.x = position.x;
+      startPosition.y = position.y;
+      deltaDistance = 0;
+    };
+
+    // some time inputsRef/outputsRef order is broken when nestedGraph change.
+    const sortedInputs = computed(() => {
+      return [...inputsRef.value].sort((aa, bb) => (aa.getBoundingClientRect().top > bb.getBoundingClientRect().top ? 1 : -1));
+    });
+    const sortedOutputs = computed(() => {
+      return [...outputsRef.value].sort((aa, bb) => (aa.getBoundingClientRect().top > bb.getBoundingClientRect().top ? 1 : -1));
+    });
+    const getWH = () => {
+      return getNodeSize(thisRef.value, sortedInputs.value, sortedOutputs.value);
+    };
+    onMounted(() => {
+      ctx.emit("updatePosition", getWH());
+    });
+
+    const onMoveNode = (event: MouseEvent | TouchEvent) => {
+      if (!isDragging.value) return;
+      const { clientX, clientY } = getClientPos(event);
+      const x = clientX - offset.value.x;
+      const y = clientY - offset.value.y;
+      const newPosition = { ...getWH(), x, y };
+      ctx.emit("updatePosition", newPosition);
+      deltaDistance = (startPosition.x - x) ** 2 + (startPosition.y - y) ** 2;
+    };
+
+    const onEndNode = () => {
+      isDragging.value = false;
+      ctx.emit("nodeDragEnd");
+      if (deltaDistance > deltaDistanceThredhold) {
+        ctx.emit("savePosition");
+      }
+    };
+
+    // edge event
+    const onStartEdge = (event: MouseEvent | TouchEvent, direction: NewEdgeEventDirection, index: number) => {
+      isNewEdge.value = true;
+      const { clientX, clientY } = getClientPos(event);
+      ctx.emit("newEdgeStart", {
+        nodeId: props.nodeData.nodeId,
+        x: clientX,
+        y: clientY,
+        index,
+        direction,
+      });
+    };
+    const onEndEdge = () => {
+      isNewEdge.value = false;
+      ctx.emit("newEdgeEnd");
+    };
+    const onMoveEdge = (event: MouseEvent | TouchEvent) => {
+      if (!isNewEdge.value) return;
+      const { clientX, clientY } = getClientPos(event);
+      ctx.emit("newEdge", { x: clientX, y: clientY });
+    };
+    // end of edge event
+
+    watchEffect((onCleanup) => {
+      if (isDragging.value) {
+        window.addEventListener("mousemove", onMoveNode);
+        window.addEventListener("mouseup", onEndNode);
+        window.addEventListener("touchmove", onMoveNode, { passive: false });
+        window.addEventListener("touchend", onEndNode);
+        onCleanup(() => {
+          window.removeEventListener("mousemove", onMoveNode);
+          window.removeEventListener("mouseup", onEndNode);
+          window.removeEventListener("touchmove", onMoveNode);
+          window.removeEventListener("touchend", onEndNode);
+        });
+      }
+    });
+
+    watchEffect((onCleanup) => {
+      if (isNewEdge.value) {
+        window.addEventListener("mousemove", onMoveEdge);
+        window.addEventListener("mouseup", onEndEdge);
+        window.addEventListener("touchmove", onMoveEdge, { passive: false });
+        window.addEventListener("touchend", onEndEdge);
+        onCleanup(() => {
+          window.removeEventListener("mousemove", onMoveEdge);
+          window.removeEventListener("mouseup", onEndEdge);
+          window.removeEventListener("touchmove", onMoveEdge);
+          window.removeEventListener("touchend", onEndEdge);
+        });
+      }
+    });
+
+    const transform = computed(() => {
+      return getTransformStyle(props.nodeData, isDragging.value);
+    });
+    const expectNearNode = computed(() => {
+      return props.nodeData.nodeId === props.nearestData?.nodeId;
+    });
+
+    const isExpectNearButton = (direction: NewEdgeEventDirection, index: number) => {
+      if (!expectNearNode.value) {
+        return false;
+      }
+      return props.nearestData?.direction === direction && props.nearestData?.index === index;
+    };
+
+    let currentWidth = 0;
+    let currentHeight = 0;
+    const focusEvent = () => {
+      if (thisRef.value) {
+        currentWidth = thisRef.value.offsetWidth;
+        currentHeight = thisRef.value.offsetHeight;
+        thisRef.value.style.width = currentWidth * 3 + "px";
+        thisRef.value.style.height = currentHeight * 3 + "px";
+        thisRef.value.style.zIndex = "100";
+      }
+      ctx.emit("updatePosition", getWH());
+    };
+    const blurEvent = () => {
+      if (thisRef.value) {
+        thisRef.value.style.width = currentWidth + "px";
+        thisRef.value.style.height = currentHeight + "px";
+        thisRef.value.style.zIndex = "auto";
+      }
+      ctx.emit("updatePosition", getWH());
+    };
+    const openNodeMenu = (event: MouseEvent) => {
+      ctx.emit("openNodeMenu", event);
+    };
+    const openNodeEditMenu = (event: MouseEvent) => {
+      if (isDragging.value || isNewEdge.value) return;
+      ctx.emit("openNodeEditMenu", event);
+    };
+    const updateAgentIndex = () => {
+      const agent = agentProfile?.agents?.[agentIndex.value];
+      ctx.emit("updateStaticNodeValue", { agentIndex: agentIndex.value, agent });
+    };
+    watch(
+      () => props.nodeData.data.agentIndex,
+      (value) => {
+        if (value !== undefined) {
+          agentIndex.value = value;
+        }
+      },
+    );
+
+    const nestedGraph = computed(() => {
+      return store.nestedGraphs[nestedGraphIndex.value];
+    });
+    const updateNestedGraphIndex = () => {
+      ctx.emit("updateNestedGraph", { nestedGraphIndex: nestedGraphIndex.value, nestedGraphId: nestedGraph.value.id });
+      ctx.emit("updatePosition", getWH());
+    };
+    watch(
+      () => props.nodeData.data.nestedGraphIndex,
+      (value) => {
+        if (value !== undefined) {
+          nestedGraphIndex.value = value;
+        }
+      },
+    );
+
+    const inputs = computed(() => {
+      if (agentProfile.isNestedGraph) {
+        return nestedGraphInputs(nestedGraph.value.graph);
+      }
+      return agentProfile.inputs;
+    });
+    const outputs = computed(() => {
+      if (agentProfile.isNestedGraph) {
+        return nestedGraph.value.graph?.metadata?.forNested?.outputs ?? agentProfile.outputs;
+      }
+      return agentProfile.outputs;
+    });
+
+    return {
+      focusEvent,
+      blurEvent,
+
+      transform,
+      onStartNode,
+      isDragging,
+      agentProfile,
+      thisRef,
+      isNewEdge,
+      onStartEdge,
+
+      inputsRef,
+      inputs,
+      outputsRef,
+      outputs,
+
+      expectNearNode,
+      isExpectNearButton,
+
+      openNodeMenu,
+      openNodeEditMenu,
+      nodeMainClass,
+      nodeHeaderClass,
+      nodeOutputClass,
+      nodeInputClass,
+
+      agentIndex,
+      updateAgentIndex,
+
+      nestedGraphs: store.nestedGraphs,
+      nestedGraphIndex,
+      nestedGraph,
+      updateNestedGraphIndex,
+    };
+  },
+});
+</script>

--- a/packages/grapys-vue/src/views/Node2.vue
+++ b/packages/grapys-vue/src/views/Node2.vue
@@ -24,8 +24,9 @@
         <div
           class="absolute right-[-10px] h-4 w-4 min-w-[12px] rounded-full"
           :class="nodeOutputClass(isExpectNearButton('inbound', index), nodeData, isConnectable)"
-          @mousedown="(e) => onStartEdge(e, 'outbound', index)"
-          @touchstart="(e) => onStartEdge(e, 'outbound', index)"
+          @click.stop
+          @mousedown.stop.prevent="(e) => onStartEdge(e, 'outbound', index)"
+          @touchstart.stop.prevent="(e) => onStartEdge(e, 'outbound', index)"
         ></div>
       </div>
     </div>
@@ -40,8 +41,9 @@
         <div
           class="absolute left-[-10px] h-4 w-4 min-w-[12px] rounded-full"
           :class="nodeInputClass(isExpectNearButton('outbound', index), nodeData, input as any, isConnectable)"
-          @mousedown="(e) => onStartEdge(e, 'inbound', index)"
-          @touchstart="(e) => onStartEdge(e, 'inbound', index)"
+          @click.stop
+          @mousedown.stop.prevent="(e) => onStartEdge(e, 'inbound', index)"
+          @touchstart.stop.prevent="(e) => onStartEdge(e, 'inbound', index)"
         ></div>
         <span class="ml-2 text-xs whitespace-nowrap">{{ input.name }}</span>
       </div>
@@ -262,6 +264,7 @@ export default defineComponent({
     };
     const openNodeEditMenu = (event: MouseEvent) => {
       if (isDragging.value || isNewEdge.value) return;
+      if (deltaDistance > deltaDistanceThredhold) return;
       ctx.emit("openNodeEditMenu", event);
     };
     const updateAgentIndex = () => {

--- a/packages/grapys-vue/src/views/Node2.vue
+++ b/packages/grapys-vue/src/views/Node2.vue
@@ -17,7 +17,7 @@
         {{ nodeData.data.guiAgentId?.replace(/Agent$/, "") }}
       </div>
     </div>
-    
+
     <div class="mt-1 flex flex-col items-end">
       <div v-for="(output, index) in outputs" :key="['out', output.name, index].join('-')" class="relative flex items-center" ref="outputsRef">
         <span class="mr-2 text-xs whitespace-nowrap">{{ output.name }}</span>
@@ -49,7 +49,6 @@
     <div class="flex w-full flex-col gap-1 p-2">
       <NodeResult :node-data="nodeData" />
     </div>
-    
   </div>
 </template>
 

--- a/packages/grapys-vue/src/views/Node2.vue
+++ b/packages/grapys-vue/src/views/Node2.vue
@@ -269,6 +269,7 @@ export default defineComponent({
     };
     const updateAgentIndex = () => {
       const agent = agentProfile?.agents?.[agentIndex.value];
+      // this is not static node value, but it works
       ctx.emit("updateStaticNodeValue", { agentIndex: agentIndex.value, agent });
     };
     watch(
@@ -286,6 +287,7 @@ export default defineComponent({
     const updateNestedGraphIndex = () => {
       ctx.emit("updateNestedGraph", { nestedGraphIndex: nestedGraphIndex.value, nestedGraphId: nestedGraph.value.id });
       ctx.emit("updatePosition", getWH());
+      // TODO remove Edge
     };
     watch(
       () => props.nodeData.data.nestedGraphIndex,
@@ -298,11 +300,13 @@ export default defineComponent({
 
     const inputs = computed(() => {
       if (agentProfile.isNestedGraph) {
+        // not do mapAgent
         return nestedGraphInputs(nestedGraph.value.graph);
       }
       return agentProfile.inputs;
     });
     const outputs = computed(() => {
+      // not do mapAgent
       if (agentProfile.isNestedGraph) {
         return nestedGraph.value.graph?.metadata?.forNested?.outputs ?? agentProfile.outputs;
       }
@@ -331,6 +335,7 @@ export default defineComponent({
 
       openNodeMenu,
       openNodeEditMenu,
+      // helper
       nodeMainClass,
       nodeHeaderClass,
       nodeOutputClass,

--- a/packages/grapys-vue/src/views/NodeEditorPanel.vue
+++ b/packages/grapys-vue/src/views/NodeEditorPanel.vue
@@ -1,0 +1,116 @@
+<template>
+  <div v-if="isOpen" class="pointer-events-auto rounded-md border border-gray-300 bg-white shadow-md w-80 p-4">
+    <div class="flex items-center justify-between mb-3">
+      <h3 class="text-lg font-semibold">Node Editor</h3>
+      <button
+        class="cursor-pointer rounded-full p-1 text-gray-600 hover:bg-gray-100"
+        @click="$emit('close')"
+        aria-label="Close"
+        title="Close"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="size-5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+
+    <div v-if="currentNode?.type === 'computed' && agentProfile?.agents" class="space-y-1 mb-3">
+      <label class="block text-xs text-gray-600">Agent</label>
+      <select class="w-full border rounded px-2 py-1" v-model.number="agentIndex" @change="onChangeAgent">
+        <option :value="key" v-for="(agent, key) in agentProfile.agents" :key="key">{{ agent }}</option>
+      </select>
+    </div>
+
+    <div v-if="agentProfile?.isNestedGraph || agentProfile?.isMap" class="space-y-1">
+      <label class="block text-xs text-gray-600">Nested Graph</label>
+      <select class="w-full border rounded px-2 py-1" v-model.number="nestedGraphIndex" @change="onChangeNestedGraph">
+        <option :value="key" v-for="(graph, key) in store.nestedGraphs" :key="key">{{ graph.name }}</option>
+      </select>
+    </div>
+
+    <div class="mt-4">
+      <div v-if="currentNode?.type === 'static'">
+        <NodeStaticValue :node-data="currentNode" @update-static-value="onUpdateStaticValue" />
+      </div>
+      <div v-else-if="currentNode?.type === 'computed'">
+        <NodeComputedParams :node-data="currentNode" :node-index="panelNodeIndex" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, watch } from 'vue';
+import { useStore } from '../store';
+import { agentProfiles, staticNodeParams } from '../utils/gui/data';
+import type { GUINodeData, AgentProfile, UpdateStaticValue } from '../utils/gui/type';
+import NodeStaticValue from './NodeStaticValue.vue';
+import NodeComputedParams from './NodeComputedParams.vue';
+
+export default defineComponent({
+  name: 'NodeEditorPanel',
+  components: {
+    NodeStaticValue,
+    NodeComputedParams,
+  },
+  props: {
+    nodeIndex: { type: Number, required: true },
+    isOpen: { type: Boolean, required: true },
+  },
+  emits: ['close'],
+  setup(props) {
+    const store = useStore();
+
+    const currentNode = computed<GUINodeData | undefined>(() => store.nodes[props.nodeIndex]);
+    const agentProfile = computed<AgentProfile | typeof staticNodeParams | undefined>(() => {
+      const node = currentNode.value;
+      if (!node) return undefined;
+      return node.type === 'computed' ? agentProfiles[node.data.guiAgentId ?? ''] : staticNodeParams;
+    });
+
+    const agentIndex = ref<number>(0);
+    const nestedGraphIndex = ref<number>(0);
+
+    // props.nodeIndex が変わったら初期値を反映
+    watch(
+      () => props.nodeIndex,
+      () => {
+        agentIndex.value = (currentNode.value?.data.agentIndex as number) ?? 0;
+        nestedGraphIndex.value = (currentNode.value?.data.nestedGraphIndex as number) ?? 0;
+      },
+      { immediate: true },
+    );
+
+    const onChangeAgent = () => {
+      const profile = agentProfile.value;
+      const agent = profile?.agents?.[agentIndex.value];
+      store.updateStaticNodeValue(props.nodeIndex, { agentIndex: agentIndex.value, agent }, true);
+    };
+
+    const onChangeNestedGraph = () => {
+      const graph = store.nestedGraphs[nestedGraphIndex.value];
+      if (!graph) return;
+      store.updateNestedGraph(props.nodeIndex, { nestedGraphIndex: nestedGraphIndex.value, nestedGraphId: graph.id });
+    };
+
+    // static/computed params editing
+    const onUpdateStaticValue = (value: UpdateStaticValue) => {
+      store.updateStaticNodeValue(props.nodeIndex, value, true);
+    };
+
+    const panelNodeIndex = computed(() => props.nodeIndex);
+
+    return {
+      store,
+      currentNode,
+      agentProfile,
+      agentIndex,
+      nestedGraphIndex,
+      onChangeAgent,
+      onChangeNestedGraph,
+      onUpdateStaticValue,
+      panelNodeIndex,
+    };
+  },
+});
+</script>

--- a/packages/grapys-vue/src/views/NodeEditorPanel.vue
+++ b/packages/grapys-vue/src/views/NodeEditorPanel.vue
@@ -1,7 +1,15 @@
 <template>
   <div v-if="isOpen" class="pointer-events-auto w-80 rounded-md border border-gray-300 bg-white p-4 shadow-md">
     <div class="mb-3 flex items-center justify-between">
-      <h3 class="text-lg font-semibold">Node Editor</h3>
+      <div class="flex flex-col">
+        <h3 class="text-lg font-semibold leading-tight">
+          {{ currentNode?.nodeId ?? 'Node Editor' }}
+        </h3>
+        <div v-if="currentNode?.type === 'computed' && headerAgentName" class="mt-0.5 text-xs text-gray-500 leading-none">
+          {{ headerAgentName }}
+        </div>
+      </div>
+
       <button class="cursor-pointer rounded-full p-1 text-gray-600 hover:bg-gray-100" @click="$emit('close')" aria-label="Close" title="Close">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="size-5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
@@ -63,6 +71,12 @@ export default defineComponent({
       return node.type === "computed" ? agentProfiles[node.data.guiAgentId ?? ""] : staticNodeParams;
     });
 
+    const headerAgentName = computed(() => {
+      const node = currentNode.value;
+      if (!node || node.type !== 'computed') return '';
+      return node.data.guiAgentId?.replace(/Agent$/, "") ?? '';
+    });
+
     const agentIndex = ref<number>(0);
     const nestedGraphIndex = ref<number>(0);
 
@@ -99,6 +113,7 @@ export default defineComponent({
       store,
       currentNode,
       agentProfile,
+      headerAgentName,
       agentIndex,
       nestedGraphIndex,
       onChangeAgent,

--- a/packages/grapys-vue/src/views/NodeEditorPanel.vue
+++ b/packages/grapys-vue/src/views/NodeEditorPanel.vue
@@ -1,29 +1,24 @@
 <template>
-  <div v-if="isOpen" class="pointer-events-auto rounded-md border border-gray-300 bg-white shadow-md w-80 p-4">
-    <div class="flex items-center justify-between mb-3">
+  <div v-if="isOpen" class="pointer-events-auto w-80 rounded-md border border-gray-300 bg-white p-4 shadow-md">
+    <div class="mb-3 flex items-center justify-between">
       <h3 class="text-lg font-semibold">Node Editor</h3>
-      <button
-        class="cursor-pointer rounded-full p-1 text-gray-600 hover:bg-gray-100"
-        @click="$emit('close')"
-        aria-label="Close"
-        title="Close"
-      >
+      <button class="cursor-pointer rounded-full p-1 text-gray-600 hover:bg-gray-100" @click="$emit('close')" aria-label="Close" title="Close">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="size-5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
         </svg>
       </button>
     </div>
 
-    <div v-if="currentNode?.type === 'computed' && agentProfile?.agents" class="space-y-1 mb-3">
+    <div v-if="currentNode?.type === 'computed' && agentProfile?.agents" class="mb-3 space-y-1">
       <label class="block text-xs text-gray-600">Agent</label>
-      <select class="w-full border rounded px-2 py-1" v-model.number="agentIndex" @change="onChangeAgent">
+      <select class="w-full rounded border px-2 py-1" v-model.number="agentIndex" @change="onChangeAgent">
         <option :value="key" v-for="(agent, key) in agentProfile.agents" :key="key">{{ agent }}</option>
       </select>
     </div>
 
     <div v-if="agentProfile?.isNestedGraph || agentProfile?.isMap" class="space-y-1">
       <label class="block text-xs text-gray-600">Nested Graph</label>
-      <select class="w-full border rounded px-2 py-1" v-model.number="nestedGraphIndex" @change="onChangeNestedGraph">
+      <select class="w-full rounded border px-2 py-1" v-model.number="nestedGraphIndex" @change="onChangeNestedGraph">
         <option :value="key" v-for="(graph, key) in store.nestedGraphs" :key="key">{{ graph.name }}</option>
       </select>
     </div>
@@ -40,15 +35,15 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed, watch } from 'vue';
-import { useStore } from '../store';
-import { agentProfiles, staticNodeParams } from '../utils/gui/data';
-import type { GUINodeData, AgentProfile, UpdateStaticValue } from '../utils/gui/type';
-import NodeStaticValue from './NodeStaticValue.vue';
-import NodeComputedParams from './NodeComputedParams.vue';
+import { defineComponent, ref, computed, watch } from "vue";
+import { useStore } from "../store";
+import { agentProfiles, staticNodeParams } from "../utils/gui/data";
+import type { GUINodeData, AgentProfile, UpdateStaticValue } from "../utils/gui/type";
+import NodeStaticValue from "./NodeStaticValue.vue";
+import NodeComputedParams from "./NodeComputedParams.vue";
 
 export default defineComponent({
-  name: 'NodeEditorPanel',
+  name: "NodeEditorPanel",
   components: {
     NodeStaticValue,
     NodeComputedParams,
@@ -57,15 +52,15 @@ export default defineComponent({
     nodeIndex: { type: Number, required: true },
     isOpen: { type: Boolean, required: true },
   },
-  emits: ['close'],
-  setup(props) {
+  emits: ["close", "updateStaticNodeValue", "updateNestedGraph"],
+  setup(props, ctx) {
     const store = useStore();
 
     const currentNode = computed<GUINodeData | undefined>(() => store.nodes[props.nodeIndex]);
     const agentProfile = computed<AgentProfile | typeof staticNodeParams | undefined>(() => {
       const node = currentNode.value;
       if (!node) return undefined;
-      return node.type === 'computed' ? agentProfiles[node.data.guiAgentId ?? ''] : staticNodeParams;
+      return node.type === "computed" ? agentProfiles[node.data.guiAgentId ?? ""] : staticNodeParams;
     });
 
     const agentIndex = ref<number>(0);
@@ -84,18 +79,18 @@ export default defineComponent({
     const onChangeAgent = () => {
       const profile = agentProfile.value;
       const agent = profile?.agents?.[agentIndex.value];
-      store.updateStaticNodeValue(props.nodeIndex, { agentIndex: agentIndex.value, agent }, true);
+      ctx.emit("updateStaticNodeValue", { agentIndex: agentIndex.value, agent });
     };
 
     const onChangeNestedGraph = () => {
       const graph = store.nestedGraphs[nestedGraphIndex.value];
       if (!graph) return;
-      store.updateNestedGraph(props.nodeIndex, { nestedGraphIndex: nestedGraphIndex.value, nestedGraphId: graph.id });
+      ctx.emit("updateNestedGraph", { nestedGraphIndex: nestedGraphIndex.value, nestedGraphId: graph.id });
     };
 
     // static/computed params editing
     const onUpdateStaticValue = (value: UpdateStaticValue) => {
-      store.updateStaticNodeValue(props.nodeIndex, value, true);
+      ctx.emit("updateStaticNodeValue", value);
     };
 
     const panelNodeIndex = computed(() => props.nodeIndex);


### PR DESCRIPTION
## やりたいこと

Nodeと内容の編集のUIを分離

## 実装内容

- Node2とNodeEditorPanelの追加
- Node2：入力を取り除いたNode
- NodeEditorPanel：Node2をクリックすると右側に表示。Node2の内容を編集するフォーム。

https://github.com/user-attachments/assets/5b5d21c6-1408-4483-803e-a0fb0a74e045



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Node Editor workflow with a side panel that opens when a node is selected, enabling quick edits to node properties.
  * Added controls to change agent and nested graph for computed nodes.
  * Upgraded node rendering with a new component featuring smoother drag-and-drop, clearer selection/focus, and streamlined edge creation.
  * Panel reliably refreshes content when switching between nodes to reflect the correct context.
  * New node context menu and edit menu actions for faster node interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->