### PR TITLE
Viewer mode: graph or json

### DIFF
--- a/packages/grapys-vue/package.json
+++ b/packages/grapys-vue/package.json
@@ -11,9 +11,10 @@
     "format": "prettier --write '{src/**/*,*}.{js,ts,vue,json}'"
   },
   "dependencies": {
-    "@highlightjs/vue-plugin": "^2.1.0",
     "@receptron/firebase-tools": "^1.0.0",
+    "@types/highlight.js": "^10.1.0",
     "firebase": "^12.2.1",
+    "highlight.js": "^11.11.1",
     "pinia": "^3.0.3",
     "vue": "^3.5.21",
     "vue-router": "^4.5.1"

--- a/packages/grapys-vue/package.json
+++ b/packages/grapys-vue/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write '{src/**/*,*}.{js,ts,vue,json}'"
   },
   "dependencies": {
+    "@highlightjs/vue-plugin": "^2.1.0",
     "@receptron/firebase-tools": "^1.0.0",
     "firebase": "^12.2.1",
     "pinia": "^3.0.3",

--- a/packages/grapys-vue/src/main.ts
+++ b/packages/grapys-vue/src/main.ts
@@ -3,16 +3,9 @@ import { createPinia } from "pinia";
 import App from "./App.vue";
 import router from "./router";
 import "./index.css";
-import "highlight.js/styles/intellij-light.css";
-import hljs from "highlight.js/lib/core";
-import json from "highlight.js/lib/languages/json";
-import hljsVuePlugin from "@highlightjs/vue-plugin";
-
-hljs.registerLanguage("json", json);
 
 const app = createApp(App);
 
 app.use(createPinia());
 app.use(router);
-app.use(hljsVuePlugin);
 app.mount("#app");

--- a/packages/grapys-vue/src/main.ts
+++ b/packages/grapys-vue/src/main.ts
@@ -3,9 +3,16 @@ import { createPinia } from "pinia";
 import App from "./App.vue";
 import router from "./router";
 import "./index.css";
+import "highlight.js/styles/intellij-light.css";
+import hljs from "highlight.js/lib/core";
+import json from "highlight.js/lib/languages/json";
+import hljsVuePlugin from "@highlightjs/vue-plugin";
+
+hljs.registerLanguage("json", json);
 
 const app = createApp(App);
 
 app.use(createPinia());
 app.use(router);
+app.use(hljsVuePlugin);
 app.mount("#app");

--- a/packages/grapys-vue/src/views/GUI.vue
+++ b/packages/grapys-vue/src/views/GUI.vue
@@ -34,6 +34,8 @@ export default defineComponent({
     const graphRunnerRef = ref();
     const { addShortcut } = useKeyboardShortcuts();
 
+    const viewerMode = ref<string>("graph");
+
     onMounted(() => {
       // Run GraphRunner: Ctrl + R
       addShortcut({
@@ -95,6 +97,10 @@ export default defineComponent({
     const showJsonView = ref(false);
     const showChat = ref(false);
 
+    const switchViewerMode = () => {
+      viewerMode.value = viewerMode.value === "graph" ? "json" : "graph";
+    };
+
     return {
       updateStaticNodeValue,
       updateNestedGraph,
@@ -110,6 +116,8 @@ export default defineComponent({
       panelKey,
 
       graphRunnerRef,
+      viewerMode,
+      switchViewerMode,
     };
   },
 });
@@ -122,12 +130,13 @@ export default defineComponent({
         <SideMenu />
       </aside>
       <main class="flex-1">
-        <GraphCanvas @open-node-editor="openNodeEditor" />
+        <GraphCanvas v-if="viewerMode === 'graph'" @open-node-editor="openNodeEditor" />
+        <JsonViewer v-if="viewerMode === 'json'" :json-data="store.graphData" :is-open="showJsonView" @close="showJsonView = false" />
         <div class="h-100vh pointer-events-none absolute top-0 right-0 z-10 flex max-h-screen flex-col items-end space-y-4 pt-4 pr-4 pb-4">
           <div class="flex flex-row items-start space-x-4">
             <button
               class="pointer-events-auto m-1 cursor-pointer items-center rounded-full border-1 border-gray-300 bg-gray-100 px-4 py-2 text-black"
-              @click="showJsonView = !showJsonView"
+              @click="switchViewerMode"
             >
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
                 <path
@@ -151,7 +160,6 @@ export default defineComponent({
             </button>
           </div>
           <div class="flex flex-row items-start space-x-4">
-            <JsonViewer v-if="showJsonView" :json-data="store.graphData" :is-open="showJsonView" @close="showJsonView = false" />
             <NodeEditorPanel
               :key="panelKey"
               v-if="isNodeEditorOpen"

--- a/packages/grapys-vue/src/views/GUI.vue
+++ b/packages/grapys-vue/src/views/GUI.vue
@@ -131,7 +131,7 @@ export default defineComponent({
       </aside>
       <main class="flex-1">
         <GraphCanvas v-if="viewerMode === 'graph'" @open-node-editor="openNodeEditor" />
-        <JsonViewer v-if="viewerMode === 'json'" :json-data="store.graphData" :is-open="showJsonView" @close="showJsonView = false" />
+        <JsonViewer v-if="viewerMode === 'json'" :json-data="store.graphData" />
         <div class="h-100vh pointer-events-none absolute top-0 right-0 z-10 flex max-h-screen flex-col items-end space-y-4 pt-4 pr-4 pb-4">
           <div class="flex flex-row items-start space-x-4">
             <button

--- a/packages/grapys-vue/src/views/GUI.vue
+++ b/packages/grapys-vue/src/views/GUI.vue
@@ -87,14 +87,13 @@ export default defineComponent({
       store.updateNestedGraph(index, value);
     };
 
-    const openNodeEditor = (_event: MouseEvent, nodeIndex: number) => {
+    const openNodeEditor = (nodeIndex: number) => {
       // remount only if different node is clicked
       if (selectedNodeIndex.value === nodeIndex) return;
       selectedNodeIndex.value = nodeIndex;
       panelKey.value += 1;
     };
 
-    const showJsonView = ref(false);
     const showChat = ref(false);
 
     const switchViewerMode = () => {
@@ -109,7 +108,6 @@ export default defineComponent({
 
       openNodeEditor,
 
-      showJsonView,
       showChat,
       selectedNodeIndex,
       isNodeEditorOpen,
@@ -168,7 +166,7 @@ export default defineComponent({
               @update-static-node-value="(v: UpdateStaticValue) => updateStaticNodeValue(selectedNodeIndex as number, v, true)"
               @update-nested-graph="(v: UpdateStaticValue) => updateNestedGraph(selectedNodeIndex as number, v)"
             />
-            <GraphRunner ref="graphRunnerRef" :class="{ hidden: !showChat }" :graph-data="store.graphData" :is-open="showChat" @close="showChat = false" />
+            <GraphRunner ref="graphRunnerRef" :class="{ hidden: !showChat }" :graph-data="store.graphData" @close="showChat = false" />
           </div>
         </div>
       </main>

--- a/packages/grapys-vue/src/views/GUI.vue
+++ b/packages/grapys-vue/src/views/GUI.vue
@@ -1,68 +1,40 @@
 <script lang="ts">
 import { defineComponent, computed, onMounted, ref, nextTick } from "vue";
-import Node2 from "./Node2.vue";
-import NodeEditorPanel from "./NodeEditorPanel.vue";
-import Edge from "./Edge.vue";
-import Loop from "./Loop.vue";
 
-import ContextEdgeMenu from "./ContextEdgeMenu.vue";
-import ContextNodeMenu from "./ContextNodeMenu.vue";
+import NodeEditorPanel from "./NodeEditorPanel.vue";
+import GraphCanvas from "./GraphCanvas.vue";
 
 import GraphRunner from "./GraphRunner.vue";
 import JsonViewer from "./JsonViewer.vue";
 
 import SideMenu from "./SideMenu.vue";
 
-import { EdgeData, NodePosition, UpdateStaticValue } from "../utils/gui/type";
+import { UpdateStaticValue } from "../utils/gui/type";
 
 import { graphChat } from "../graph/chat_tinyswallow";
 
-import { useNewEdge } from "../composable/gui";
-import { usePanAndScroll } from "../composable/usePanAndScroll";
 import { useKeyboardShortcuts } from "../composable/useKeyboardShortcuts";
-import { guiEdgeData2edgeData } from "../utils/gui/utils";
 import { useStore } from "../store";
 
 export default defineComponent({
   components: {
     SideMenu,
-    Node2,
-    Edge,
-    Loop,
-    ContextEdgeMenu,
-    ContextNodeMenu,
     NodeEditorPanel,
     GraphRunner,
     JsonViewer,
+    GraphCanvas,
   },
   setup() {
     const store = useStore();
-    const contextEdgeMenu = ref();
-    const contextNodeMenu = ref();
     const selectedNodeIndex = ref<number | null>(null);
     const isNodeEditorOpen = computed(() => selectedNodeIndex.value !== null);
     const panelKey = ref(0);
-    const mainContainer = ref();
     store.initFromGraphData(graphChat);
-
-    // ノードドラッグ状態の管理
-    const isNodeDragging = ref(false);
-
-    const handleNodeDragStart = () => {
-      isNodeDragging.value = true;
-    };
-
-    const handleNodeDragEnd = () => {
-      isNodeDragging.value = false;
-    };
 
     const graphRunnerRef = ref();
     const { addShortcut } = useKeyboardShortcuts();
 
     onMounted(() => {
-      saveNodePosition();
-      setupPanAndScroll();
-
       // Run GraphRunner: Ctrl + R
       addShortcut({
         combo: "ctrl+r",
@@ -106,12 +78,6 @@ export default defineComponent({
       });
     });
 
-    const updateNodePosition = (index: number, pos: NodePosition) => {
-      store.updateNodePosition(index, pos);
-    };
-    const saveNodePosition = () => {
-      store.saveNodePositionData();
-    };
     const updateStaticNodeValue = (index: number, value: UpdateStaticValue, saveHistory: boolean) => {
       store.updateStaticNodeValue(index, value, saveHistory);
     };
@@ -119,27 +85,6 @@ export default defineComponent({
       store.updateNestedGraph(index, value);
     };
 
-    const edgeDataList = computed<EdgeData[]>(() => {
-      return guiEdgeData2edgeData(store.edges, store.nodeRecords);
-    });
-
-    const { svgRef, newEdgeData, onNewEdgeStart, onNewEdge, onNewEdgeEnd, nearestData, edgeConnectable } = useNewEdge();
-
-    // パン（掴んで動かす）とスクロール機能のセットアップ
-    const { setupPanAndScroll } = usePanAndScroll(mainContainer, isNodeDragging, newEdgeData);
-
-    const openEdgeMenu = (event: MouseEvent, edgeIndex: number) => {
-      const rect = svgRef.value.getBoundingClientRect();
-      contextEdgeMenu.value.openMenu(event, rect, edgeIndex);
-    };
-    const closeMenu = () => {
-      contextEdgeMenu.value.closeMenu();
-      contextNodeMenu.value.closeMenu();
-    };
-    const openNodeMenu = (event: MouseEvent, nodeIndex: number) => {
-      const rect = svgRef.value.getBoundingClientRect();
-      contextNodeMenu.value.openMenu(event, rect, nodeIndex);
-    };
     const openNodeEditor = (_event: MouseEvent, nodeIndex: number) => {
       // remount only if different node is clicked
       if (selectedNodeIndex.value === nodeIndex) return;
@@ -151,39 +96,18 @@ export default defineComponent({
     const showChat = ref(false);
 
     return {
-      updateNodePosition,
-      saveNodePosition,
       updateStaticNodeValue,
       updateNestedGraph,
 
       store,
 
-      edgeDataList,
-      onNewEdgeStart,
-      onNewEdge,
-      onNewEdgeEnd,
-      newEdgeData,
-      svgRef,
-      nearestData,
-
-      contextEdgeMenu,
-      contextNodeMenu,
-      openEdgeMenu,
-      openNodeMenu,
       openNodeEditor,
-      closeMenu,
-
-      edgeConnectable,
 
       showJsonView,
       showChat,
-      mainContainer,
       selectedNodeIndex,
       isNodeEditorOpen,
       panelKey,
-
-      handleNodeDragStart,
-      handleNodeDragEnd,
 
       graphRunnerRef,
     };
@@ -198,54 +122,7 @@ export default defineComponent({
         <SideMenu />
       </aside>
       <main class="flex-1">
-        <div
-          ref="mainContainer"
-          class="relative overflow-auto rounded-md border-4 border-gray-200"
-          style="width: calc(100vw - 192px); height: calc(100vh - 40px)"
-          @click="closeMenu"
-        >
-          <div class="relative" style="width: 2000px; height: 1500px">
-            <Loop />
-            <svg x="0" y="0" class="pointer-events-none absolute h-full w-full" ref="svgRef">
-              <Edge
-                v-for="(edge, index) in edgeDataList"
-                :key="['edge', edge.source, edge.target, index].join('-')"
-                :source-data="edge.source"
-                :target-data="edge.target"
-                class="pointer-events-auto"
-                @dblclick="(e: MouseEvent) => openEdgeMenu(e, index)"
-              />
-              <Edge
-                v-if="newEdgeData"
-                :source-data="newEdgeData.source"
-                :target-data="newEdgeData.target"
-                class="pointer-events-auto"
-                :is-connectable="edgeConnectable"
-              />
-            </svg>
-            <Node2
-              v-for="(node, index) in store.nodes"
-              :key="[node.nodeId, index].join('-')"
-              :node-index="index"
-              :node-data="node"
-              :nearest-data="nearestData"
-              :is-connectable="edgeConnectable"
-              @update-position="(pos: NodePosition) => updateNodePosition(index, pos)"
-              @update-static-node-value="updateStaticNodeValue(index, $event, true)"
-              @update-nested-graph="updateNestedGraph(index, $event)"
-              @save-position="saveNodePosition"
-              @new-edge-start="onNewEdgeStart"
-              @new-edge="onNewEdge"
-              @new-edge-end="onNewEdgeEnd"
-              @open-node-menu="(e: MouseEvent) => openNodeMenu(e, index)"
-              @open-node-edit-menu="(e: MouseEvent) => openNodeEditor(e, index)"
-              @node-drag-start="handleNodeDragStart"
-              @node-drag-end="handleNodeDragEnd"
-            />
-            <ContextEdgeMenu ref="contextEdgeMenu" />
-            <ContextNodeMenu ref="contextNodeMenu" />
-          </div>
-        </div>
+        <GraphCanvas @open-node-editor="openNodeEditor" />
         <div class="h-100vh pointer-events-none absolute top-0 right-0 z-10 flex max-h-screen flex-col items-end space-y-4 pt-4 pr-4 pb-4">
           <div class="flex flex-row items-start space-x-4">
             <button
@@ -275,16 +152,15 @@ export default defineComponent({
           </div>
           <div class="flex flex-row items-start space-x-4">
             <JsonViewer v-if="showJsonView" :json-data="store.graphData" :is-open="showJsonView" @close="showJsonView = false" />
-            <GraphRunner ref="graphRunnerRef" :class="{ hidden: !showChat }" :graph-data="store.graphData" :is-open="showChat" @close="showChat = false" />
             <NodeEditorPanel
               :key="panelKey"
-              :is-open="isNodeEditorOpen"
               v-if="isNodeEditorOpen"
               :node-index="selectedNodeIndex as number"
               @close="selectedNodeIndex = null"
               @update-static-node-value="(v: UpdateStaticValue) => updateStaticNodeValue(selectedNodeIndex as number, v, true)"
               @update-nested-graph="(v: UpdateStaticValue) => updateNestedGraph(selectedNodeIndex as number, v)"
             />
+            <GraphRunner ref="graphRunnerRef" :class="{ hidden: !showChat }" :graph-data="store.graphData" :is-open="showChat" @close="showChat = false" />
           </div>
         </div>
       </main>

--- a/packages/grapys-vue/src/views/GraphCanvas.vue
+++ b/packages/grapys-vue/src/views/GraphCanvas.vue
@@ -1,49 +1,32 @@
 <script lang="ts">
-import { defineComponent, computed, onMounted, ref, nextTick } from "vue";
+import { defineComponent, onMounted, ref, computed } from "vue";
 import Node2 from "./Node2.vue";
-import NodeEditorPanel from "./NodeEditorPanel.vue";
 import Edge from "./Edge.vue";
 import Loop from "./Loop.vue";
 
 import ContextEdgeMenu from "./ContextEdgeMenu.vue";
 import ContextNodeMenu from "./ContextNodeMenu.vue";
-
-import GraphRunner from "./GraphRunner.vue";
-import JsonViewer from "./JsonViewer.vue";
-
-import SideMenu from "./SideMenu.vue";
-
-import { EdgeData, NodePosition, UpdateStaticValue } from "../utils/gui/type";
-
-import { graphChat } from "../graph/chat_tinyswallow";
-
 import { useNewEdge } from "../composable/gui";
 import { usePanAndScroll } from "../composable/usePanAndScroll";
-import { useKeyboardShortcuts } from "../composable/useKeyboardShortcuts";
 import { guiEdgeData2edgeData } from "../utils/gui/utils";
 import { useStore } from "../store";
+import type { EdgeData, NodePosition, UpdateStaticValue } from "../utils/gui/type";
 
 export default defineComponent({
+  name: "GraphCanvas",
   components: {
-    SideMenu,
     Node2,
     Edge,
     Loop,
     ContextEdgeMenu,
     ContextNodeMenu,
-    NodeEditorPanel,
-    GraphRunner,
-    JsonViewer,
   },
-  setup() {
+  emits: ["open-node-editor"],
+  setup(props, { emit }) {
     const store = useStore();
     const contextEdgeMenu = ref();
     const contextNodeMenu = ref();
-    const selectedNodeIndex = ref<number | null>(null);
-    const isNodeEditorOpen = computed(() => selectedNodeIndex.value !== null);
-    const panelKey = ref(0);
     const mainContainer = ref();
-    store.initFromGraphData(graphChat);
 
     // ノードドラッグ状態の管理
     const isNodeDragging = ref(false);
@@ -56,54 +39,8 @@ export default defineComponent({
       isNodeDragging.value = false;
     };
 
-    const graphRunnerRef = ref();
-    const { addShortcut } = useKeyboardShortcuts();
-
     onMounted(() => {
-      saveNodePosition();
       setupPanAndScroll();
-
-      // Run GraphRunner: Ctrl + R
-      addShortcut({
-        combo: "ctrl+r",
-        handler: () => {
-          nextTick(() => {
-            try {
-              graphRunnerRef.value?.run?.();
-            } catch (error) {
-              console.error(error);
-            }
-          });
-        },
-      });
-
-      // Toggle Chat Viewer: Cmd/Ctrl + L
-      addShortcut({
-        combo: "mod+l",
-        handler: () => {
-          showChat.value = !showChat.value;
-        },
-      });
-
-      // Undo: Cmd/Ctrl + Z
-      addShortcut({
-        combo: "mod+z",
-        handler: () => {
-          if (store.undoable) {
-            store.undo();
-          }
-        },
-      });
-
-      // Redo: Cmd/Ctrl + Shift + Z
-      addShortcut({
-        combo: "mod+shift+z",
-        handler: () => {
-          if (store.redoable) {
-            store.redo();
-          }
-        },
-      });
     });
 
     const updateNodePosition = (index: number, pos: NodePosition) => {
@@ -140,15 +77,9 @@ export default defineComponent({
       const rect = svgRef.value.getBoundingClientRect();
       contextNodeMenu.value.openMenu(event, rect, nodeIndex);
     };
-    const openNodeEditor = (_event: MouseEvent, nodeIndex: number) => {
-      // remount only if different node is clicked
-      if (selectedNodeIndex.value === nodeIndex) return;
-      selectedNodeIndex.value = nodeIndex;
-      panelKey.value += 1;
+    const openNodeEditor = (event: MouseEvent, nodeIndex: number) => {
+      emit("open-node-editor", event, nodeIndex);
     };
-
-    const showJsonView = ref(false);
-    const showChat = ref(false);
 
     return {
       updateNodePosition,
@@ -175,119 +106,56 @@ export default defineComponent({
 
       edgeConnectable,
 
-      showJsonView,
-      showChat,
       mainContainer,
-      selectedNodeIndex,
-      isNodeEditorOpen,
-      panelKey,
-
       handleNodeDragStart,
       handleNodeDragEnd,
-
-      graphRunnerRef,
     };
   },
 });
 </script>
 
 <template>
-  <div>
-    <div class="flex h-screen">
-      <aside class="w-48 p-4 text-center">
-        <SideMenu />
-      </aside>
-      <main class="flex-1">
-        <div
-          ref="mainContainer"
-          class="relative overflow-auto rounded-md border-4 border-gray-200"
-          style="width: calc(100vw - 192px); height: calc(100vh - 40px)"
-          @click="closeMenu"
-        >
-          <div class="relative" style="width: 2000px; height: 1500px">
-            <Loop />
-            <svg x="0" y="0" class="pointer-events-none absolute h-full w-full" ref="svgRef">
-              <Edge
-                v-for="(edge, index) in edgeDataList"
-                :key="['edge', edge.source, edge.target, index].join('-')"
-                :source-data="edge.source"
-                :target-data="edge.target"
-                class="pointer-events-auto"
-                @dblclick="(e: MouseEvent) => openEdgeMenu(e, index)"
-              />
-              <Edge
-                v-if="newEdgeData"
-                :source-data="newEdgeData.source"
-                :target-data="newEdgeData.target"
-                class="pointer-events-auto"
-                :is-connectable="edgeConnectable"
-              />
-            </svg>
-            <Node2
-              v-for="(node, index) in store.nodes"
-              :key="[node.nodeId, index].join('-')"
-              :node-index="index"
-              :node-data="node"
-              :nearest-data="nearestData"
-              :is-connectable="edgeConnectable"
-              @update-position="(pos: NodePosition) => updateNodePosition(index, pos)"
-              @update-static-node-value="updateStaticNodeValue(index, $event, true)"
-              @update-nested-graph="updateNestedGraph(index, $event)"
-              @save-position="saveNodePosition"
-              @new-edge-start="onNewEdgeStart"
-              @new-edge="onNewEdge"
-              @new-edge-end="onNewEdgeEnd"
-              @open-node-menu="(e: MouseEvent) => openNodeMenu(e, index)"
-              @open-node-edit-menu="(e: MouseEvent) => openNodeEditor(e, index)"
-              @node-drag-start="handleNodeDragStart"
-              @node-drag-end="handleNodeDragEnd"
-            />
-            <ContextEdgeMenu ref="contextEdgeMenu" />
-            <ContextNodeMenu ref="contextNodeMenu" />
-          </div>
-        </div>
-        <div class="h-100vh pointer-events-none absolute top-0 right-0 z-10 flex max-h-screen flex-col items-end space-y-4 pt-4 pr-4 pb-4">
-          <div class="flex flex-row items-start space-x-4">
-            <button
-              class="pointer-events-auto m-1 cursor-pointer items-center rounded-full border-1 border-gray-300 bg-gray-100 px-4 py-2 text-black"
-              @click="showJsonView = !showJsonView"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M14.25 9.75 16.5 12l-2.25 2.25m-4.5 0L7.5 12l2.25-2.25M6 20.25h12A2.25 2.25 0 0 0 20.25 18V6A2.25 2.25 0 0 0 18 3.75H6A2.25 2.25 0 0 0 3.75 6v12A2.25 2.25 0 0 0 6 20.25Z"
-                />
-              </svg>
-            </button>
-            <button
-              class="pointer-events-auto m-1 cursor-pointer items-center rounded-full border-1 border-gray-300 bg-gray-100 px-4 py-2 text-black"
-              @click="showChat = !showChat"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"
-                />
-              </svg>
-            </button>
-          </div>
-          <div class="flex flex-row items-start space-x-4">
-            <JsonViewer v-if="showJsonView" :json-data="store.graphData" :is-open="showJsonView" @close="showJsonView = false" />
-            <GraphRunner ref="graphRunnerRef" :class="{ hidden: !showChat }" :graph-data="store.graphData" :is-open="showChat" @close="showChat = false" />
-            <NodeEditorPanel
-              :key="panelKey"
-              :is-open="isNodeEditorOpen"
-              v-if="isNodeEditorOpen"
-              :node-index="selectedNodeIndex as number"
-              @close="selectedNodeIndex = null"
-              @update-static-node-value="(v: UpdateStaticValue) => updateStaticNodeValue(selectedNodeIndex as number, v, true)"
-              @update-nested-graph="(v: UpdateStaticValue) => updateNestedGraph(selectedNodeIndex as number, v)"
-            />
-          </div>
-        </div>
-      </main>
+  <div ref="mainContainer" class="relative box-border h-full overflow-auto rounded-md border-4 border-gray-200" @click="closeMenu">
+    <div class="relative h-full w-full">
+      <Loop />
+      <svg x="0" y="0" class="pointer-events-none absolute h-full w-full" ref="svgRef">
+        <Edge
+          v-for="(edge, index) in edgeDataList"
+          :key="['edge', edge.source, edge.target, index].join('-')"
+          :source-data="edge.source"
+          :target-data="edge.target"
+          class="pointer-events-auto"
+          @dblclick="(e: MouseEvent) => openEdgeMenu(e, index)"
+        />
+        <Edge
+          v-if="newEdgeData"
+          :source-data="newEdgeData.source"
+          :target-data="newEdgeData.target"
+          class="pointer-events-auto"
+          :is-connectable="edgeConnectable"
+        />
+      </svg>
+      <Node2
+        v-for="(node, index) in store.nodes"
+        :key="[node.nodeId, index].join('-')"
+        :node-index="index"
+        :node-data="node"
+        :nearest-data="nearestData"
+        :is-connectable="edgeConnectable"
+        @update-position="(pos: NodePosition) => updateNodePosition(index, pos)"
+        @update-static-node-value="updateStaticNodeValue(index, $event, true)"
+        @update-nested-graph="updateNestedGraph(index, $event)"
+        @save-position="saveNodePosition"
+        @new-edge-start="onNewEdgeStart"
+        @new-edge="onNewEdge"
+        @new-edge-end="onNewEdgeEnd"
+        @open-node-menu="(e: MouseEvent) => openNodeMenu(e, index)"
+        @open-node-edit-menu="(e: MouseEvent) => openNodeEditor(e, index)"
+        @node-drag-start="handleNodeDragStart"
+        @node-drag-end="handleNodeDragEnd"
+      />
+      <ContextEdgeMenu ref="contextEdgeMenu" />
+      <ContextNodeMenu ref="contextNodeMenu" />
     </div>
   </div>
 </template>

--- a/packages/grapys-vue/src/views/GraphCanvas.vue
+++ b/packages/grapys-vue/src/views/GraphCanvas.vue
@@ -77,8 +77,8 @@ export default defineComponent({
       const rect = svgRef.value.getBoundingClientRect();
       contextNodeMenu.value.openMenu(event, rect, nodeIndex);
     };
-    const openNodeEditor = (event: MouseEvent, nodeIndex: number) => {
-      emit("open-node-editor", event, nodeIndex);
+    const openNodeEditor = (nodeIndex: number) => {
+      emit("open-node-editor", nodeIndex);
     };
 
     return {
@@ -150,7 +150,7 @@ export default defineComponent({
         @new-edge="onNewEdge"
         @new-edge-end="onNewEdgeEnd"
         @open-node-menu="(e: MouseEvent) => openNodeMenu(e, index)"
-        @open-node-edit-menu="(e: MouseEvent) => openNodeEditor(e, index)"
+        @open-node-edit-menu="openNodeEditor(index)"
         @node-drag-start="handleNodeDragStart"
         @node-drag-end="handleNodeDragEnd"
       />

--- a/packages/grapys-vue/src/views/GraphCanvas.vue
+++ b/packages/grapys-vue/src/views/GraphCanvas.vue
@@ -1,0 +1,293 @@
+<script lang="ts">
+import { defineComponent, computed, onMounted, ref, nextTick } from "vue";
+import Node2 from "./Node2.vue";
+import NodeEditorPanel from "./NodeEditorPanel.vue";
+import Edge from "./Edge.vue";
+import Loop from "./Loop.vue";
+
+import ContextEdgeMenu from "./ContextEdgeMenu.vue";
+import ContextNodeMenu from "./ContextNodeMenu.vue";
+
+import GraphRunner from "./GraphRunner.vue";
+import JsonViewer from "./JsonViewer.vue";
+
+import SideMenu from "./SideMenu.vue";
+
+import { EdgeData, NodePosition, UpdateStaticValue } from "../utils/gui/type";
+
+import { graphChat } from "../graph/chat_tinyswallow";
+
+import { useNewEdge } from "../composable/gui";
+import { usePanAndScroll } from "../composable/usePanAndScroll";
+import { useKeyboardShortcuts } from "../composable/useKeyboardShortcuts";
+import { guiEdgeData2edgeData } from "../utils/gui/utils";
+import { useStore } from "../store";
+
+export default defineComponent({
+  components: {
+    SideMenu,
+    Node2,
+    Edge,
+    Loop,
+    ContextEdgeMenu,
+    ContextNodeMenu,
+    NodeEditorPanel,
+    GraphRunner,
+    JsonViewer,
+  },
+  setup() {
+    const store = useStore();
+    const contextEdgeMenu = ref();
+    const contextNodeMenu = ref();
+    const selectedNodeIndex = ref<number | null>(null);
+    const isNodeEditorOpen = computed(() => selectedNodeIndex.value !== null);
+    const panelKey = ref(0);
+    const mainContainer = ref();
+    store.initFromGraphData(graphChat);
+
+    // ノードドラッグ状態の管理
+    const isNodeDragging = ref(false);
+
+    const handleNodeDragStart = () => {
+      isNodeDragging.value = true;
+    };
+
+    const handleNodeDragEnd = () => {
+      isNodeDragging.value = false;
+    };
+
+    const graphRunnerRef = ref();
+    const { addShortcut } = useKeyboardShortcuts();
+
+    onMounted(() => {
+      saveNodePosition();
+      setupPanAndScroll();
+
+      // Run GraphRunner: Ctrl + R
+      addShortcut({
+        combo: "ctrl+r",
+        handler: () => {
+          nextTick(() => {
+            try {
+              graphRunnerRef.value?.run?.();
+            } catch (error) {
+              console.error(error);
+            }
+          });
+        },
+      });
+
+      // Toggle Chat Viewer: Cmd/Ctrl + L
+      addShortcut({
+        combo: "mod+l",
+        handler: () => {
+          showChat.value = !showChat.value;
+        },
+      });
+
+      // Undo: Cmd/Ctrl + Z
+      addShortcut({
+        combo: "mod+z",
+        handler: () => {
+          if (store.undoable) {
+            store.undo();
+          }
+        },
+      });
+
+      // Redo: Cmd/Ctrl + Shift + Z
+      addShortcut({
+        combo: "mod+shift+z",
+        handler: () => {
+          if (store.redoable) {
+            store.redo();
+          }
+        },
+      });
+    });
+
+    const updateNodePosition = (index: number, pos: NodePosition) => {
+      store.updateNodePosition(index, pos);
+    };
+    const saveNodePosition = () => {
+      store.saveNodePositionData();
+    };
+    const updateStaticNodeValue = (index: number, value: UpdateStaticValue, saveHistory: boolean) => {
+      store.updateStaticNodeValue(index, value, saveHistory);
+    };
+    const updateNestedGraph = (index: number, value: UpdateStaticValue) => {
+      store.updateNestedGraph(index, value);
+    };
+
+    const edgeDataList = computed<EdgeData[]>(() => {
+      return guiEdgeData2edgeData(store.edges, store.nodeRecords);
+    });
+
+    const { svgRef, newEdgeData, onNewEdgeStart, onNewEdge, onNewEdgeEnd, nearestData, edgeConnectable } = useNewEdge();
+
+    // パン（掴んで動かす）とスクロール機能のセットアップ
+    const { setupPanAndScroll } = usePanAndScroll(mainContainer, isNodeDragging, newEdgeData);
+
+    const openEdgeMenu = (event: MouseEvent, edgeIndex: number) => {
+      const rect = svgRef.value.getBoundingClientRect();
+      contextEdgeMenu.value.openMenu(event, rect, edgeIndex);
+    };
+    const closeMenu = () => {
+      contextEdgeMenu.value.closeMenu();
+      contextNodeMenu.value.closeMenu();
+    };
+    const openNodeMenu = (event: MouseEvent, nodeIndex: number) => {
+      const rect = svgRef.value.getBoundingClientRect();
+      contextNodeMenu.value.openMenu(event, rect, nodeIndex);
+    };
+    const openNodeEditor = (_event: MouseEvent, nodeIndex: number) => {
+      // remount only if different node is clicked
+      if (selectedNodeIndex.value === nodeIndex) return;
+      selectedNodeIndex.value = nodeIndex;
+      panelKey.value += 1;
+    };
+
+    const showJsonView = ref(false);
+    const showChat = ref(false);
+
+    return {
+      updateNodePosition,
+      saveNodePosition,
+      updateStaticNodeValue,
+      updateNestedGraph,
+
+      store,
+
+      edgeDataList,
+      onNewEdgeStart,
+      onNewEdge,
+      onNewEdgeEnd,
+      newEdgeData,
+      svgRef,
+      nearestData,
+
+      contextEdgeMenu,
+      contextNodeMenu,
+      openEdgeMenu,
+      openNodeMenu,
+      openNodeEditor,
+      closeMenu,
+
+      edgeConnectable,
+
+      showJsonView,
+      showChat,
+      mainContainer,
+      selectedNodeIndex,
+      isNodeEditorOpen,
+      panelKey,
+
+      handleNodeDragStart,
+      handleNodeDragEnd,
+
+      graphRunnerRef,
+    };
+  },
+});
+</script>
+
+<template>
+  <div>
+    <div class="flex h-screen">
+      <aside class="w-48 p-4 text-center">
+        <SideMenu />
+      </aside>
+      <main class="flex-1">
+        <div
+          ref="mainContainer"
+          class="relative overflow-auto rounded-md border-4 border-gray-200"
+          style="width: calc(100vw - 192px); height: calc(100vh - 40px)"
+          @click="closeMenu"
+        >
+          <div class="relative" style="width: 2000px; height: 1500px">
+            <Loop />
+            <svg x="0" y="0" class="pointer-events-none absolute h-full w-full" ref="svgRef">
+              <Edge
+                v-for="(edge, index) in edgeDataList"
+                :key="['edge', edge.source, edge.target, index].join('-')"
+                :source-data="edge.source"
+                :target-data="edge.target"
+                class="pointer-events-auto"
+                @dblclick="(e: MouseEvent) => openEdgeMenu(e, index)"
+              />
+              <Edge
+                v-if="newEdgeData"
+                :source-data="newEdgeData.source"
+                :target-data="newEdgeData.target"
+                class="pointer-events-auto"
+                :is-connectable="edgeConnectable"
+              />
+            </svg>
+            <Node2
+              v-for="(node, index) in store.nodes"
+              :key="[node.nodeId, index].join('-')"
+              :node-index="index"
+              :node-data="node"
+              :nearest-data="nearestData"
+              :is-connectable="edgeConnectable"
+              @update-position="(pos: NodePosition) => updateNodePosition(index, pos)"
+              @update-static-node-value="updateStaticNodeValue(index, $event, true)"
+              @update-nested-graph="updateNestedGraph(index, $event)"
+              @save-position="saveNodePosition"
+              @new-edge-start="onNewEdgeStart"
+              @new-edge="onNewEdge"
+              @new-edge-end="onNewEdgeEnd"
+              @open-node-menu="(e: MouseEvent) => openNodeMenu(e, index)"
+              @open-node-edit-menu="(e: MouseEvent) => openNodeEditor(e, index)"
+              @node-drag-start="handleNodeDragStart"
+              @node-drag-end="handleNodeDragEnd"
+            />
+            <ContextEdgeMenu ref="contextEdgeMenu" />
+            <ContextNodeMenu ref="contextNodeMenu" />
+          </div>
+        </div>
+        <div class="h-100vh pointer-events-none absolute top-0 right-0 z-10 flex max-h-screen flex-col items-end space-y-4 pt-4 pr-4 pb-4">
+          <div class="flex flex-row items-start space-x-4">
+            <button
+              class="pointer-events-auto m-1 cursor-pointer items-center rounded-full border-1 border-gray-300 bg-gray-100 px-4 py-2 text-black"
+              @click="showJsonView = !showJsonView"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M14.25 9.75 16.5 12l-2.25 2.25m-4.5 0L7.5 12l2.25-2.25M6 20.25h12A2.25 2.25 0 0 0 20.25 18V6A2.25 2.25 0 0 0 18 3.75H6A2.25 2.25 0 0 0 3.75 6v12A2.25 2.25 0 0 0 6 20.25Z"
+                />
+              </svg>
+            </button>
+            <button
+              class="pointer-events-auto m-1 cursor-pointer items-center rounded-full border-1 border-gray-300 bg-gray-100 px-4 py-2 text-black"
+              @click="showChat = !showChat"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div class="flex flex-row items-start space-x-4">
+            <JsonViewer v-if="showJsonView" :json-data="store.graphData" :is-open="showJsonView" @close="showJsonView = false" />
+            <GraphRunner ref="graphRunnerRef" :class="{ hidden: !showChat }" :graph-data="store.graphData" :is-open="showChat" @close="showChat = false" />
+            <NodeEditorPanel
+              :key="panelKey"
+              :is-open="isNodeEditorOpen"
+              v-if="isNodeEditorOpen"
+              :node-index="selectedNodeIndex as number"
+              @close="selectedNodeIndex = null"
+              @update-static-node-value="(v: UpdateStaticValue) => updateStaticNodeValue(selectedNodeIndex as number, v, true)"
+              @update-nested-graph="(v: UpdateStaticValue) => updateNestedGraph(selectedNodeIndex as number, v)"
+            />
+          </div>
+        </div>
+      </main>
+    </div>
+  </div>
+</template>

--- a/packages/grapys-vue/src/views/GraphRunner.vue
+++ b/packages/grapys-vue/src/views/GraphRunner.vue
@@ -127,10 +127,6 @@ export default defineComponent({
       type: Object as PropType<GraphData>,
       required: true,
     },
-    isOpen: {
-      type: Boolean,
-      default: false,
-    },
   },
   emits: ["close"],
   setup(props, { emit }) {

--- a/packages/grapys-vue/src/views/JsonViewer.vue
+++ b/packages/grapys-vue/src/views/JsonViewer.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, computed } from "vue";
 
 export default defineComponent({
   name: "JsonViewer",
@@ -9,11 +9,19 @@ export default defineComponent({
       required: true,
     },
   },
+  setup(props) {
+    const code = computed(() => {
+      return JSON.stringify(props.jsonData, null, 2);
+    });
+    return {
+      code,
+    };
+  },
 });
 </script>
 
 <template>
-  <div class="relative box-border h-full overflow-auto rounded-md border-4 border-gray-200">
-    <pre class="p-6 font-mono text-xs break-words whitespace-pre-wrap">{{ JSON.stringify(jsonData, null, 2) }}</pre>
+  <div class="relative box-border h-full overflow-auto rounded-md border-4 border-gray-200 bg-white">
+    <highlightjs language="json" :code="code" class="h-full" />
   </div>
 </template>

--- a/packages/grapys-vue/src/views/JsonViewer.vue
+++ b/packages/grapys-vue/src/views/JsonViewer.vue
@@ -8,46 +8,12 @@ export default defineComponent({
       type: Object,
       required: true,
     },
-    isOpen: {
-      type: Boolean,
-      default: false,
-    },
-  },
-  emits: ["close"],
-  setup(props, { emit }) {
-    const onClickClose = () => {
-      emit("close");
-    };
-
-    return {
-      onClickClose,
-    };
   },
 });
 </script>
 
 <template>
-  <div class="pointer-events-auto flex max-h-[calc(100vh-90px)] w-100 flex-col">
-    <!-- header -->
-    <div class="flex cursor-pointer items-center justify-between rounded-t-lg border border-gray-300 bg-gray-100 p-3 text-black">
-      <div class="flex items-center font-bold">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M14.25 9.75 16.5 12l-2.25 2.25m-4.5 0L7.5 12l2.25-2.25M6 20.25h12A2.25 2.25 0 0 0 20.25 18V6A2.25 2.25 0 0 0 18 3.75H6A2.25 2.25 0 0 0 3.75 6v12A2.25 2.25 0 0 0 6 20.25Z"
-          />
-        </svg>
-        <span>JSON Data</span>
-      </div>
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6" @click="onClickClose">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
-      </svg>
-    </div>
-
-    <!-- content -->
-    <div class="overflow-hidden overflow-y-scroll border border-gray-300 bg-white shadow-lg transition-all duration-300 ease-in-out">
-      <pre class="p-6 font-mono text-xs break-words whitespace-pre-wrap">{{ JSON.stringify(jsonData, null, 2) }}</pre>
-    </div>
+  <div class="relative box-border h-full overflow-auto rounded-md border-4 border-gray-200">
+    <pre class="p-6 font-mono text-xs break-words whitespace-pre-wrap">{{ JSON.stringify(jsonData, null, 2) }}</pre>
   </div>
 </template>

--- a/packages/grapys-vue/src/views/JsonViewer.vue
+++ b/packages/grapys-vue/src/views/JsonViewer.vue
@@ -1,5 +1,10 @@
 <script lang="ts">
 import { defineComponent, computed } from "vue";
+import "highlight.js/styles/intellij-light.css";
+import hljs from "highlight.js/lib/core";
+import json from "highlight.js/lib/languages/json";
+
+hljs.registerLanguage("json", json);
 
 export default defineComponent({
   name: "JsonViewer",
@@ -11,7 +16,7 @@ export default defineComponent({
   },
   setup(props) {
     const code = computed(() => {
-      return JSON.stringify(props.jsonData, null, 2);
+      return hljs.highlight(JSON.stringify(props.jsonData, null, 2), { language: "json" }).value;
     });
     return {
       code,
@@ -22,6 +27,6 @@ export default defineComponent({
 
 <template>
   <div class="relative box-border h-full overflow-auto rounded-md border-4 border-gray-200 bg-white">
-    <highlightjs language="json" :code="code" class="h-full" />
+    <pre v-html="code"></pre>
   </div>
 </template>

--- a/packages/grapys-vue/src/views/NodeEditorPanel.vue
+++ b/packages/grapys-vue/src/views/NodeEditorPanel.vue
@@ -1,11 +1,11 @@
 <template>
-  <div v-if="isOpen" class="pointer-events-auto w-80 rounded-md border border-gray-300 bg-white p-4 shadow-md">
+  <div class="pointer-events-auto w-80 rounded-md border border-gray-300 bg-white p-4 shadow-md">
     <div class="mb-3 flex items-center justify-between">
       <div class="flex flex-col">
-        <h3 class="text-lg font-semibold leading-tight">
-          {{ currentNode?.nodeId ?? 'Node Editor' }}
+        <h3 class="text-lg leading-tight font-semibold">
+          {{ currentNode?.nodeId ?? "Node Editor" }}
         </h3>
-        <div v-if="currentNode?.type === 'computed' && headerAgentName" class="mt-0.5 text-xs text-gray-500 leading-none">
+        <div v-if="currentNode?.type === 'computed' && headerAgentName" class="mt-0.5 text-xs leading-none text-gray-500">
           {{ headerAgentName }}
         </div>
       </div>
@@ -58,7 +58,6 @@ export default defineComponent({
   },
   props: {
     nodeIndex: { type: Number, required: true },
-    isOpen: { type: Boolean, required: true },
   },
   emits: ["close", "updateStaticNodeValue", "updateNestedGraph"],
   setup(props, ctx) {
@@ -73,8 +72,8 @@ export default defineComponent({
 
     const headerAgentName = computed(() => {
       const node = currentNode.value;
-      if (!node || node.type !== 'computed') return '';
-      return node.data.guiAgentId?.replace(/Agent$/, "") ?? '';
+      if (!node || node.type !== "computed") return "";
+      return node.data.guiAgentId?.replace(/Agent$/, "") ?? "";
     });
 
     const agentIndex = ref<number>(0);


### PR DESCRIPTION
## やりたいこと

- JSON ViewerをGraph編集エリアと切り替え可能にする

## 実装したこと

- Graph編集エリアとJSON の表示を2モードで切り替え
  - Graphモード
  - JSON Viewerモード


https://github.com/user-attachments/assets/28ca1767-ada9-455d-b35f-cf026499e7a8




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Toggle between Graph view and a highlighted JSON view.
  - Unified, interactive Graph Canvas drives node/edge interactions and opens the node editor.

- Refactor
  - Consolidated rendering into the Graph Canvas and simplified UI flow between graph, JSON, and node editor.
  - Streamlined Node Editor, JSON Viewer, and runner presentation/controls.

- Chores
  - Added syntax-highlighting dependencies to improve JSON display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->