### PR TITLE
chore: bump GitHub Actions to latest + Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [22.x, 24.x]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v6
       with:


### PR DESCRIPTION
Mechanical bump of GitHub Actions to current latest and (where applicable) extend Node matrix to include 24.x. See commit message for details. Auto-generated across receptron/* + isamu/* source repos. CI on this PR is the verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build workflow to use a newer version of the repository checkout action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->